### PR TITLE
Authentication

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -29,3 +29,5 @@ jobs:
 
       - name: Execute Gradle build
         run: ./gradlew build
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE }}

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,6 +8,13 @@ In the root of the project run:
 ./gradlew backend:run
 ```
 
+### Setup notes:
+
+In order to enable firebase authentication the environment variable `GOOGLE_APPLICATION_CREDENTIALS`
+or `FIREBASE_CONFIG` must be set to either a path to a service account key json or a service account key json.
+See [Initialize the SDK](https://firebase.google.com/docs/admin/setup#initialize-sdk) in firebases docs for information
+on how to obtain a service account key.
+
 ## Testing
 
 In the root of the project run:

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val http4k_version: String by project
+val logback_classis_version: String by project
+val firebase_admin_verion: String by project
 
 plugins {
     kotlin("jvm") version "1.6.10"
@@ -17,7 +19,8 @@ repositories {
 dependencies {
     implementation(platform("org.http4k:http4k-bom:$http4k_version"))
     implementation("org.http4k:http4k-core")
-    implementation("com.google.firebase:firebase-admin:8.1.0")
+    implementation("ch.qos.logback:logback-classic:$logback_classis_version")
+    implementation("com.google.firebase:firebase-admin:$firebase_admin_verion")
 
     testImplementation("org.http4k:http4k-testing-hamkrest")
     testImplementation(kotlin("test"))

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 dependencies {
     implementation(platform("org.http4k:http4k-bom:$http4k_version"))
     implementation("org.http4k:http4k-core")
+    implementation("org.http4k:http4k-testing-hamkrest")
     testImplementation(kotlin("test"))
 }
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -17,7 +17,9 @@ repositories {
 dependencies {
     implementation(platform("org.http4k:http4k-bom:$http4k_version"))
     implementation("org.http4k:http4k-core")
-    implementation("org.http4k:http4k-testing-hamkrest")
+    implementation("com.google.firebase:firebase-admin:8.1.0")
+
+    testImplementation("org.http4k:http4k-testing-hamkrest")
     testImplementation(kotlin("test"))
 }
 

--- a/backend/src/main/kotlin/Main.kt
+++ b/backend/src/main/kotlin/Main.kt
@@ -1,12 +1,47 @@
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.FirebaseToken
 import org.http4k.core.HttpHandler
+import org.http4k.core.RequestContexts
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Status.Companion.UNAUTHORIZED
+import org.http4k.core.then
+import org.http4k.filter.ServerFilters
+import org.http4k.lens.RequestContextKey
+import org.http4k.routing.bind
+import org.http4k.routing.routes
 import org.http4k.server.SunHttp
 import org.http4k.server.asServer
 
 fun main() {
+    FirebaseApp.initializeApp()
+
+    val requestContexts = RequestContexts()
+    val firebaseTokenKey = RequestContextKey.optional<FirebaseToken>(requestContexts)
+    val attachRequestContexts = ServerFilters.InitialiseRequestContext(requestContexts)
+    val attachAuthentication = TokenAuthenticator(::verifyFirebaseToken).addAuthentication(firebaseTokenKey)
+
     val echoHandler: HttpHandler = { request -> Response(OK).body(request.bodyString()) }
-    val echoServer = echoHandler.asServer(SunHttp(8000))
+
+    val greetingHandler: HttpHandler = { request ->
+        val user = firebaseTokenKey(request)
+        if (user == null) {
+            Response(UNAUTHORIZED)
+        } else {
+            Response(OK).body("Hello ${user.name}!")
+        }
+    }
+
+    val routingHttpHandler = routes(
+        "/echo" bind echoHandler,
+        "/greet" bind greetingHandler,
+    )
+
+    val echoServer = attachRequestContexts
+        .then(attachAuthentication)
+        .then(routingHttpHandler)
+        .asServer(SunHttp(8000))
+
     echoServer.start()
     println("Server started on port ${echoServer.port()}.")
     echoServer.block() // makes sure we don't exit main.

--- a/backend/src/main/kotlin/TokenAuthenticator.kt
+++ b/backend/src/main/kotlin/TokenAuthenticator.kt
@@ -9,13 +9,13 @@ import org.http4k.lens.RequestContextLens
 /**
  * Attaches a [TOKEN] to a request through [addAuthentication] if the request has enough information to create a valid token.
  * @param TOKEN the type of token. This should carry enough information to identify a user.
+ * @param verifyToken verifies the token string, returning the token if verified, null if invalid.
  * @param extractToken extracts the unverified string token from the request, returns null if the token cannot be found.
  * Defaults to [extractBearerToken]
- * @param verifyToken verifies the token string, returning the token if verified, null if invalid.
  */
 class TokenAuthenticator<TOKEN>(
-    private val extractToken: (Request) -> String? = ::extractBearerToken,
-    private val verifyToken: (String) -> TOKEN?
+    private val verifyToken: (String) -> TOKEN?,
+    private val extractToken: (Request) -> String? = ::extractBearerToken
 ) {
     /**
      * @param key the lens used to add and receive the token from a [Request].

--- a/backend/src/main/kotlin/TokenAuthenticator.kt
+++ b/backend/src/main/kotlin/TokenAuthenticator.kt
@@ -1,5 +1,4 @@
 import org.http4k.core.Filter
-import org.http4k.core.HttpHandler
 import org.http4k.core.Request
 import org.http4k.core.with
 import org.http4k.lens.RequestContextLens
@@ -8,7 +7,7 @@ import org.http4k.lens.RequestContextLens
  * Attaches a [TOKEN] to a request through [addAuthentication] if the request has enough information to create a valid token.
  * @param TOKEN the type of token. This should carry enough information to identify a user.
  * @param extractToken extracts the unverified string token from the request, returns null if the token cannot be found.
- * Defaults to extracting from an `Authentication: Bearer <TOKEN>` style header.
+ * Defaults to [extractBearerToken]
  * @param verifyToken verifies the token string, returning the token if verified, null if invalid.
  */
 class TokenAuthenticator<TOKEN>(
@@ -20,14 +19,14 @@ class TokenAuthenticator<TOKEN>(
      * @return a [Filter] which attaches the appropriate [TOKEN] to the request if the string token is verified.
      */
     fun addAuthentication(key: RequestContextLens<TOKEN?>): Filter {
-        return Filter { nextHandler: HttpHandler ->
-            contextHandler@{ request: Request ->
+        return Filter { nextHandler ->
+            response@{ request ->
                 val tokenString = extractToken(request)
-                    ?: return@contextHandler nextHandler(request)
+                    ?: return@response nextHandler(request)
                 val token = verifyToken(tokenString)
-                    ?: return@contextHandler nextHandler(request)
+                    ?: return@response nextHandler(request)
                 val requestWithContext = request.with(key of token)
-                nextHandler(requestWithContext)
+                return@response nextHandler(requestWithContext)
             }
         }
     }
@@ -35,6 +34,12 @@ class TokenAuthenticator<TOKEN>(
 
 private val bearerRegex = Regex("Bearer: (.*)")
 
+/**
+ * Extracts the `Token` from `Authentication: Bearer <Token>` style header.
+ * @param request the request containing an authentication bearer token.
+ * @return the string bearer token
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc6750#section-2.1">Authorization Request Header Field</a>
+ */
 fun extractBearerToken(request: Request): String? {
     val authenticationHeader = request.header("Authentication")
         ?: return null

--- a/backend/src/main/kotlin/TokenAuthenticator.kt
+++ b/backend/src/main/kotlin/TokenAuthenticator.kt
@@ -1,3 +1,6 @@
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseAuthException
+import com.google.firebase.auth.FirebaseToken
 import org.http4k.core.Filter
 import org.http4k.core.Request
 import org.http4k.core.with
@@ -39,4 +42,19 @@ fun extractBearerToken(request: Request): String? {
     val bearerRegex = Regex("Bearer: (.*)")
     val (token) = bearerRegex.find(authenticationHeader)?.destructured ?: return null
     return token
+}
+
+/**
+ * Verifies a firebase [idToken]. Assumes there is an initialized [FirebaseApp](com.google.firebase.FirebaseApp)
+ * @param idToken the token to verify
+ * @param checkRevoked check to see if the token has been revoked (defaults to true)
+ * @return a [FirebaseToken] if verified, otherwise null
+ * @see <a href=https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_the_firebase_admin_sdk>verify-id-tokens</a>
+ */
+fun verifyFirebaseToken(idToken: String, checkRevoked: Boolean = true): FirebaseToken? {
+    return try {
+        FirebaseAuth.getInstance().verifyIdToken(idToken, checkRevoked)
+    } catch (unauthenticated: FirebaseAuthException) {
+        return null
+    }
 }

--- a/backend/src/main/kotlin/TokenAuthenticator.kt
+++ b/backend/src/main/kotlin/TokenAuthenticator.kt
@@ -1,0 +1,44 @@
+import org.http4k.core.Filter
+import org.http4k.core.HttpHandler
+import org.http4k.core.Request
+import org.http4k.core.with
+import org.http4k.lens.RequestContextLens
+
+/**
+ * Attaches a [TOKEN] to a request through [addAuthentication] if the request has enough information to create a valid token.
+ * @param TOKEN the type of token. This should carry enough information to identify a user.
+ * @param extractToken extracts the unverified string token from the request, returns null if the token cannot be found.
+ * Defaults to extracting from an `Authentication: Bearer <TOKEN>` style header.
+ * @param verifyToken verifies the token string, returning the token if verified, null if invalid.
+ */
+class TokenAuthenticator<TOKEN>(
+    private val extractToken: (Request) -> String? = ::extractBearerToken,
+    private val verifyToken: (String) -> TOKEN?
+) {
+    /**
+     * @param key the lens used to add and receive the token from a [Request].
+     * @return a [Filter] which attaches the appropriate [TOKEN] to the request if the string token is verified.
+     */
+    fun addAuthentication(key: RequestContextLens<TOKEN?>): Filter {
+        return Filter { nextHandler: HttpHandler ->
+            contextHandler@{ request: Request ->
+                val tokenString = extractToken(request)
+                    ?: return@contextHandler nextHandler(request)
+                val token = verifyToken(tokenString)
+                    ?: return@contextHandler nextHandler(request)
+                val requestWithContext = request.with(key of token)
+                nextHandler(requestWithContext)
+            }
+        }
+    }
+}
+
+private val bearerRegex = Regex("Bearer: (.*)")
+
+fun extractBearerToken(request: Request): String? {
+    val authenticationHeader = request.header("Authentication")
+        ?: return null
+    val (token) = bearerRegex.find(authenticationHeader)?.destructured
+        ?: return null
+    return token
+}

--- a/backend/src/test/kotlin/TokenAuthenticatorKtTest.kt
+++ b/backend/src/test/kotlin/TokenAuthenticatorKtTest.kt
@@ -1,0 +1,22 @@
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+internal class TokenAuthenticatorKtTest {
+    @Test
+    internal fun `check extract bearer token returns null on empty request`() {
+        val request = Request(GET, "/")
+        val extractedToken = extractBearerToken(request)
+        assertNull(extractedToken)
+    }
+
+    @Test
+    internal fun `check extract bearer token returns the token when request has a bearer token`() {
+        val request = Request(GET, "/").header("Authentication", "Bearer: Marcus")
+        val extractedToken = extractBearerToken(request)
+        assertThat(extractedToken, equalTo("Marcus"))
+    }
+}

--- a/backend/src/test/kotlin/TokenAuthenticatorKtTest.kt
+++ b/backend/src/test/kotlin/TokenAuthenticatorKtTest.kt
@@ -4,7 +4,10 @@ import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
 
+@Execution(CONCURRENT)
 internal class TokenAuthenticatorKtTest {
     @Test
     internal fun `check extract bearer token returns null on empty request`() {

--- a/backend/src/test/kotlin/TokenAuthenticatorTest.kt
+++ b/backend/src/test/kotlin/TokenAuthenticatorTest.kt
@@ -7,7 +7,10 @@ import org.http4k.filter.ServerFilters
 import org.http4k.hamkrest.hasStatus
 import org.http4k.lens.RequestContextKey
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT
 
+@Execution(CONCURRENT)
 internal class TokenAuthenticatorTest {
 
 
@@ -68,8 +71,8 @@ internal class TokenAuthenticatorTest {
 
         // the stack of Filters and our final request handler
         val authenticatedHandler = initialiseRequestContextFilter
-                .then(addAuthenticationFilter)
-                .then(authenticatedRequestHandler)
+            .then(addAuthenticationFilter)
+            .then(authenticatedRequestHandler)
 
         val request = Request(GET, "/")
         val response = authenticatedHandler(request)
@@ -101,8 +104,8 @@ internal class TokenAuthenticatorTest {
 
         // the stack of Filters and our final request handler
         val authenticatedHandler = initialiseRequestContextFilter
-                .then(addAuthenticationFilter)
-                .then(authenticatedRequestHandler)
+            .then(addAuthenticationFilter)
+            .then(authenticatedRequestHandler)
 
         val request = Request(GET, "/")
         val response = authenticatedHandler(request)

--- a/backend/src/test/kotlin/TokenAuthenticatorTest.kt
+++ b/backend/src/test/kotlin/TokenAuthenticatorTest.kt
@@ -1,0 +1,112 @@
+import com.natpryce.hamkrest.assertion.assertThat
+import org.http4k.core.*
+import org.http4k.core.Method.GET
+import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Status.Companion.UNAUTHORIZED
+import org.http4k.filter.ServerFilters
+import org.http4k.hamkrest.hasStatus
+import org.http4k.lens.RequestContextKey
+import org.junit.jupiter.api.Test
+
+internal class TokenAuthenticatorTest {
+
+
+    @Test
+    internal fun `check does not add any context if no token found`() {
+        // initialize the request context store for user token
+        val contextStore = RequestContexts()
+        val initialiseRequestContextFilter = ServerFilters.InitialiseRequestContext(contextStore)
+        val tokenKey = RequestContextKey.optional<String>(contextStore, "user token")
+
+        // create a TokenAuthenticator that always fails to extract a token.
+        val tokenAuthenticator = TokenAuthenticator(extractToken = { null }, verifyToken = { "Token" })
+
+        // create the Filter for adding "user token" contexts to requests
+        val addAuthenticationFilter = tokenAuthenticator.addAuthentication(tokenKey)
+
+        // a simple handler that checks to see if any token is attached to the request
+        val authenticatedRequestHandler: HttpHandler = { request ->
+            if (tokenKey(request) != null) {
+                Response(OK)
+            } else {
+                Response(UNAUTHORIZED)
+            }
+        }
+
+        // the stack of Filters and our final request handler
+        val authenticatedHandler = initialiseRequestContextFilter
+            .then(addAuthenticationFilter)
+            .then(authenticatedRequestHandler)
+
+        val request = Request(GET, "/")
+        val response = authenticatedHandler(request)
+
+        assertThat(response, hasStatus(UNAUTHORIZED))
+    }
+
+    @Test
+    internal fun `check does not attach the token if verifier returns null`() {
+        // initialize the request context store for user token
+        val contextStore = RequestContexts()
+        val initialiseRequestContextFilter = ServerFilters.InitialiseRequestContext(contextStore)
+        val tokenKey = RequestContextKey.optional<String>(contextStore, "user token")
+
+        // this authenticator finds a token everytime, but fails to validate it.
+        val tokenAuthenticator = TokenAuthenticator<String>(extractToken = { "Token String" }, verifyToken = { null })
+
+        // create the Filter for adding "user token" contexts to requests
+        val addAuthenticationFilter = tokenAuthenticator.addAuthentication(tokenKey)
+
+        // a simple handler that checks to see if any token is attached to the request
+        val authenticatedRequestHandler: HttpHandler = { request ->
+            if (tokenKey(request) != null) {
+                Response(OK)
+            } else {
+                Response(UNAUTHORIZED)
+            }
+        }
+
+        // the stack of Filters and our final request handler
+        val authenticatedHandler = initialiseRequestContextFilter
+                .then(addAuthenticationFilter)
+                .then(authenticatedRequestHandler)
+
+        val request = Request(GET, "/")
+        val response = authenticatedHandler(request)
+
+        assertThat(response, hasStatus(UNAUTHORIZED))
+    }
+
+    @Test
+    internal fun `check attaches the request context if token string found and validated`() {
+        // initialize the request context store for user token
+        val contextStore = RequestContexts()
+        val initialiseRequestContextFilter = ServerFilters.InitialiseRequestContext(contextStore)
+        val tokenKey = RequestContextKey.optional<String>(contextStore, "user token")
+
+        // this authenticator finds and validates the token everytime
+        val tokenAuthenticator = TokenAuthenticator(extractToken = { "Token String" }, verifyToken = { "Token Value" })
+
+        // create the Filter for adding "user token" contexts to requests
+        val addAuthenticationFilter = tokenAuthenticator.addAuthentication(tokenKey)
+
+        // a simple handler that checks to see if any token is attached to the request
+        val authenticatedRequestHandler: HttpHandler = { request ->
+            if (tokenKey(request) != null) {
+                Response(OK)
+            } else {
+                Response(UNAUTHORIZED)
+            }
+        }
+
+        // the stack of Filters and our final request handler
+        val authenticatedHandler = initialiseRequestContextFilter
+                .then(addAuthenticationFilter)
+                .then(authenticatedRequestHandler)
+
+        val request = Request(GET, "/")
+        val response = authenticatedHandler(request)
+
+        assertThat(response, hasStatus(OK))
+    }
+}

--- a/backend/src/test/resources/junit-platform.properties
+++ b/backend/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+# suppress inspection "UnusedProperty" for whole file
+junit.jupiter.execution.parallel.enabled = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 kotlin.code.style=official
 http4k_version=4.19.0.0
+logback_classis_version=1.2.10
+firebase_admin_verion=8.1.0


### PR DESCRIPTION
Resolves #2 by setting up authentication on the backend. Also added docs to alleviate a potentially confusing error message (we cannot check in the service account key, so everyone needs to get thier own.) The code documentation in [TokenAuthenticator](https://github.com/CobeyH/SENG-480A/blob/021bf55a7e30f56b0117bbb96e7f1b0f6671e467/backend/src/main/kotlin/TokenAuthenticator.kt) is *not* a standard I want to set, but hopfully makes the code super clear while http4k and kotlin are potentially new. I've also updated [Main](https://github.com/CobeyH/SENG-480A/blob/021bf55a7e30f56b0117bbb96e7f1b0f6671e467/backend/src/main/kotlin/Main.kt) with an authenticated `greet` endpoint to showcase routing and authentication.

Still to do

- [x] Add a service account key to CI env using github secrets