### PR TITLE
Created Rides and Groups use title-slug IDs and are now linked

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "react-leaflet": "^3.2.5",
         "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.0",
+        "react-slugify": "^2.1.0",
         "typescript": "^4.5.5",
         "web-vitals": "^0.2.4"
       },
@@ -9625,9 +9626,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "funding": [
         {
           "type": "individual",
@@ -16055,6 +16056,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-slugify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-slugify/-/react-slugify-2.1.0.tgz",
+      "integrity": "sha512-X+kYdGP1WumAX2exool+1lwjLSZ1dDCaCzwF0KvDWHjPfCD4hxtHvok4oyZEZro2lioaR+lCtyVG8ti2Yvpnsg=="
     },
     "node_modules/react-style-singleton": {
       "version": "2.1.1",
@@ -26119,9 +26125,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.0",
@@ -30645,6 +30651,11 @@
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
       }
+    },
+    "react-slugify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-slugify/-/react-slugify-2.1.0.tgz",
+      "integrity": "sha512-X+kYdGP1WumAX2exool+1lwjLSZ1dDCaCzwF0KvDWHjPfCD4hxtHvok4oyZEZro2lioaR+lCtyVG8ti2Yvpnsg=="
     },
     "react-style-singleton": {
       "version": "2.1.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "react-leaflet": "^3.2.5",
         "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.0",
-        "react-slugify": "^2.1.0",
+        "slugify": "^1.6.5",
         "typescript": "^4.5.5",
         "web-vitals": "^0.2.4"
       },
@@ -16057,11 +16057,6 @@
         }
       }
     },
-    "node_modules/react-slugify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-slugify/-/react-slugify-2.1.0.tgz",
-      "integrity": "sha512-X+kYdGP1WumAX2exool+1lwjLSZ1dDCaCzwF0KvDWHjPfCD4hxtHvok4oyZEZro2lioaR+lCtyVG8ti2Yvpnsg=="
-    },
     "node_modules/react-style-singleton": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
@@ -16893,6 +16888,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/sockjs": {
@@ -30652,11 +30655,6 @@
         "workbox-webpack-plugin": "^6.4.1"
       }
     },
-    "react-slugify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-slugify/-/react-slugify-2.1.0.tgz",
-      "integrity": "sha512-X+kYdGP1WumAX2exool+1lwjLSZ1dDCaCzwF0KvDWHjPfCD4hxtHvok4oyZEZro2lioaR+lCtyVG8ti2Yvpnsg=="
-    },
     "react-style-singleton": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
@@ -31268,6 +31266,11 @@
           "dev": true
         }
       }
+    },
+    "slugify": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
     },
     "sockjs": {
       "version": "0.3.24",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-leaflet": "^3.2.5",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
+    "react-slugify": "^2.1.0",
     "typescript": "^4.5.5",
     "web-vitals": "^0.2.4"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react-leaflet": "^3.2.5",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
-    "react-slugify": "^2.1.0",
+    "slugify": "^1.6.5",
     "typescript": "^4.5.5",
     "web-vitals": "^0.2.4"
   },

--- a/frontend/src/firebase.tsx
+++ b/frontend/src/firebase.tsx
@@ -29,6 +29,7 @@ const firebaseConfig = {
 };
 
 export const DB_GROUP_COLLECT = "groups";
+export const DB_GROUP_RIDES_FIELD = DB_GROUP_COLLECT + "/rides";
 export const DB_USER_COLLECT = "users";
 export const DB_RIDE_COLLECT = "rides";
 

--- a/frontend/src/firebase.tsx
+++ b/frontend/src/firebase.tsx
@@ -29,7 +29,7 @@ const firebaseConfig = {
 };
 
 export const DB_GROUP_COLLECT = "groups";
-export const DB_GROUP_RIDES_FIELD = DB_GROUP_COLLECT + "/rides";
+export const DB_GROUP_RIDES_FIELD = "rides";
 export const DB_USER_COLLECT = "users";
 export const DB_RIDE_COLLECT = "rides";
 

--- a/frontend/src/firebase.tsx
+++ b/frontend/src/firebase.tsx
@@ -29,7 +29,6 @@ const firebaseConfig = {
 };
 
 export const DB_GROUP_COLLECT = "groups";
-export const DB_GROUP_RIDES_FIELD = "rides";
 export const DB_USER_COLLECT = "users";
 export const DB_RIDE_COLLECT = "rides";
 

--- a/frontend/src/firebase.tsx
+++ b/frontend/src/firebase.tsx
@@ -28,6 +28,10 @@ const firebaseConfig = {
   measurementId: "G-4QXLHB625R",
 };
 
+export const DB_GROUP_COLLECT = "groups";
+export const DB_USER_COLLECT = "users";
+export const DB_RIDE_COLLECT = "rides";
+
 // Initialize Firebase
 const app = initializeApp(firebaseConfig, "web-frontend");
 export const auth = getAuth(app);
@@ -38,11 +42,11 @@ export const signInWithGoogle = async () => {
   try {
     const response = await signInWithPopup(auth, googleProvider);
     const user = response.user;
-    const q = query(ref(db, "users"), equalTo(user.uid, "uid"));
+    const q = query(ref(db, DB_USER_COLLECT), equalTo(user.uid, "uid"));
     const snapshot = await get(q);
     // If the user doesn't exist then add them.
     if (!snapshot.exists()) {
-      await set(ref(db, "users/" + user.uid), {
+      await set(ref(db, `${DB_USER_COLLECT}/${user.uid}`), {
         uid: user.uid,
         name: user.displayName,
         authProvider: "google",
@@ -75,7 +79,7 @@ export const registerWithEmailAndPassword = async (
     const res = await createUserWithEmailAndPassword(auth, email, password);
     const user = res.user;
     console.log(user.uid, user.displayName, user.email);
-    await set(ref(db, "users/" + user.uid), {
+    await set(ref(db, `${DB_USER_COLLECT}/${user.uid}`), {
       uid: user.uid,
       name: name,
       authProvider: "local",

--- a/frontend/src/firebase.tsx
+++ b/frontend/src/firebase.tsx
@@ -31,6 +31,14 @@ const firebaseConfig = {
 export const DB_GROUP_COLLECT = "groups";
 export const DB_USER_COLLECT = "users";
 export const DB_RIDE_COLLECT = "rides";
+export const DB_KEY_SLUG_OPTS = {
+  replacement: "-",
+  remove: undefined,
+  lower: true,
+  strict: true,
+  locale: "en",
+  trim: true,
+};
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig, "web-frontend");

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -3,7 +3,7 @@ import { Button, Heading, Input, InputGroup, Text } from "@chakra-ui/react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth, db, DB_GROUP_COLLECT } from "../firebase";
 import { useNavigate } from "react-router-dom";
-import { equalTo, get, query, ref, set } from "firebase/database";
+import { get, query, ref, set } from "firebase/database";
 import slugify from "react-slugify";
 
 type ValidatableFiled<T> = {

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -4,7 +4,7 @@ import { useAuthState } from "react-firebase-hooks/auth";
 import { auth, db, DB_GROUP_COLLECT } from "../firebase";
 import { useNavigate } from "react-router-dom";
 import { get, query, ref, set } from "firebase/database";
-import slugify from "react-slugify";
+import slugify from "slugify";
 
 type ValidatableFiled<T> = {
   field: T;

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Button, Heading, Input, InputGroup, Text } from "@chakra-ui/react";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { auth, db, DB_GROUP_COLLECT } from "../firebase";
+import { auth, db, DB_GROUP_COLLECT, DB_KEY_SLUG_OPTS } from "../firebase";
 import { useNavigate } from "react-router-dom";
 import { get, query, ref, set } from "firebase/database";
 import slugify from "slugify";
@@ -19,7 +19,7 @@ export type Group = {
 };
 
 const createGroup = async (group: Group, userId: string) => {
-  group.id = slugify(group.name);
+  group.id = slugify(group.name, DB_KEY_SLUG_OPTS);
   if ((await get(query(ref(db, `${DB_GROUP_COLLECT}/${group.id}`)))).exists()) {
     /* TODO: increment id */
     throw new Error("Group ID already exists");

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -1,19 +1,32 @@
 import React, { useState } from "react";
 import { Button, Heading, Input, InputGroup, Text } from "@chakra-ui/react";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { auth, db } from "../firebase";
+import { auth, db, DB_GROUP_COLLECT } from "../firebase";
 import { useNavigate } from "react-router-dom";
-import { ref, set } from "firebase/database";
-import { Group } from "./GroupsListPage";
+import { equalTo, get, query, ref, set } from "firebase/database";
+import slugify from "react-slugify";
 
 type ValidatableFiled<T> = {
   field: T;
   invalid: boolean;
 };
 
+export type Group = {
+  id: string;
+  name: string;
+  rides: string[];
+  members: { [key: string]: boolean };
+};
+
 const createGroup = async (group: Group, userId: string) => {
+  group.id = slugify(group.name);
+  if ((await get(query(ref(db, `${DB_GROUP_COLLECT}/${group.id}`)))).exists()) {
+    /* TODO: increment id */
+    throw new Error("Group ID already exists");
+  }
   group.members[userId] = true;
-  await set(ref(db, `groups/${group.id}`), group);
+  await set(ref(db, `${DB_GROUP_COLLECT}/${group.id}`), group);
+  return group;
 };
 
 const CreateGroup = () => {
@@ -47,10 +60,10 @@ const CreateGroup = () => {
         <Button
           onClick={() => {
             if (user?.uid !== undefined) {
-              const id = `${user.uid}_${name}`;
-              createGroup({ id, name, rides: [], members: {} }, user.uid).then(
-                () => navigate(`/group/${id}`)
-              );
+              createGroup(
+                { id: "", name, rides: [], members: {} },
+                user.uid
+              ).then((group) => navigate(`/group/${group.id}`));
             }
           }}
         >

--- a/frontend/src/pages/CreateRide.tsx
+++ b/frontend/src/pages/CreateRide.tsx
@@ -1,28 +1,47 @@
 import React, { useMemo, useRef, useState } from "react";
 import { Button, Heading, Input, InputGroup, Text } from "@chakra-ui/react";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { auth, db } from "../firebase";
-import { useNavigate } from "react-router-dom";
-import { ref, push, set } from "firebase/database";
-import { Ride, defaultMapCenter } from "./RidePage";
+import {
+  auth,
+  db,
+  DB_GROUP_COLLECT,
+  DB_GROUP_RIDES_FIELD,
+  DB_RIDE_COLLECT,
+} from "../firebase";
+import { useNavigate, useParams } from "react-router-dom";
+import { ref, set, get, query } from "firebase/database";
+import { defaultMapCenter } from "./RidePage";
 import { MapContainer, TileLayer, Marker } from "react-leaflet";
 import { icon } from "leaflet";
 import startIconImg from "../images/Arrow Circle Up_8.png";
 import endIconImg from "../images/Arrow Circle Down_8.png";
+import slugify from "react-slugify";
 
 type ValidatableField<T> = {
   field: T;
   invalid: boolean;
 };
 
-const ridesRef = ref(db, "rides");
-const createRide = async (ride: Ride) => {
-  const newRideRef = push(ridesRef);
-  await set(newRideRef, ride);
-  return newRideRef.key;
+export type Ride = {
+  id: string;
+  name: string;
+  start: [number, number];
+  end: [number, number];
 };
 
-const CreateGroup = () => {
+const createRide = async (ride: Ride, groupId: string) => {
+  ride.id = slugify(ride.name);
+  if ((await get(query(ref(db, `${DB_GROUP_COLLECT}/${ride.id}`)))).exists()) {
+    /* TODO: increment id */
+    throw new Error("Group ID already exists");
+  }
+  await set(ref(db, `${DB_RIDE_COLLECT}/${ride.id}`), ride);
+  await set(ref(db, `${DB_GROUP_RIDES_FIELD}/${ride.id}`), true);
+  return ride;
+};
+
+const CreateRide = () => {
+  const { groupId } = useParams();
   const [user] = useAuthState(auth);
   const [{ field: title, invalid: invalidTitle }, setTitle] = useState<
     ValidatableField<string>
@@ -61,7 +80,7 @@ const CreateGroup = () => {
         <Text mb={"8px"}>Title</Text>
         <Input
           value={title}
-          placeholder={"Title"}
+          placeholder={"Ride Name"}
           onInput={(e) =>
             setTitle({
               field: e.currentTarget.value,
@@ -72,11 +91,17 @@ const CreateGroup = () => {
         />
         <Button
           onClick={() => {
-            createRide({ title, start: startPosition, end: endPosition }).then(
-              (id) => {
-                navigate(`/ride/${id}`);
-              }
-            );
+            if (groupId) {
+              const ride = {
+                id: "",
+                name: title,
+                start: startPosition,
+                end: endPosition,
+              };
+              createRide(ride, groupId).then(() =>
+                navigate(`/group/${groupId}`)
+              );
+            }
           }}
         >
           Create
@@ -94,7 +119,7 @@ const CreateGroup = () => {
   );
 };
 
-export default CreateGroup;
+export default CreateRide;
 
 interface MarkerProperties {
   onDragEnd: (position: L.LatLng) => void;

--- a/frontend/src/pages/CreateRide.tsx
+++ b/frontend/src/pages/CreateRide.tsx
@@ -15,7 +15,7 @@ import { MapContainer, TileLayer, Marker } from "react-leaflet";
 import { icon } from "leaflet";
 import startIconImg from "../images/Arrow Circle Up_8.png";
 import endIconImg from "../images/Arrow Circle Down_8.png";
-import slugify from "react-slugify";
+import slugify from "slugify";
 
 type ValidatableField<T> = {
   field: T;

--- a/frontend/src/pages/CreateRide.tsx
+++ b/frontend/src/pages/CreateRide.tsx
@@ -1,7 +1,13 @@
 import React, { useMemo, useRef, useState } from "react";
 import { Button, Heading, Input, InputGroup, Text } from "@chakra-ui/react";
 import { useAuthState } from "react-firebase-hooks/auth";
-import { auth, db, DB_GROUP_COLLECT, DB_RIDE_COLLECT } from "../firebase";
+import {
+  auth,
+  db,
+  DB_GROUP_COLLECT,
+  DB_KEY_SLUG_OPTS,
+  DB_RIDE_COLLECT,
+} from "../firebase";
 import { useNavigate, useParams } from "react-router-dom";
 import { ref, set, get, query } from "firebase/database";
 import { defaultMapCenter } from "./RidePage";
@@ -24,7 +30,7 @@ export type Ride = {
 };
 
 const createRide = async (ride: Ride, groupId: string) => {
-  ride.id = slugify(ride.name);
+  ride.id = slugify(ride.name, DB_KEY_SLUG_OPTS);
   if ((await get(query(ref(db, `${DB_GROUP_COLLECT}/${ride.id}`)))).exists()) {
     /* TODO: increment id */
     throw new Error("Group ID already exists");

--- a/frontend/src/pages/CreateRide.tsx
+++ b/frontend/src/pages/CreateRide.tsx
@@ -36,7 +36,13 @@ const createRide = async (ride: Ride, groupId: string) => {
     throw new Error("Group ID already exists");
   }
   await set(ref(db, `${DB_RIDE_COLLECT}/${ride.id}`), ride);
-  await set(ref(db, `${DB_GROUP_RIDES_FIELD}/${ride.id}`), true);
+  await set(
+    ref(
+      db,
+      `${DB_GROUP_COLLECT}/${groupId}/${DB_GROUP_RIDES_FIELD}/${ride.id}`
+    ),
+    true
+  );
   return ride;
 };
 

--- a/frontend/src/pages/CreateRide.tsx
+++ b/frontend/src/pages/CreateRide.tsx
@@ -1,13 +1,7 @@
 import React, { useMemo, useRef, useState } from "react";
 import { Button, Heading, Input, InputGroup, Text } from "@chakra-ui/react";
 import { useAuthState } from "react-firebase-hooks/auth";
-import {
-  auth,
-  db,
-  DB_GROUP_COLLECT,
-  DB_GROUP_RIDES_FIELD,
-  DB_RIDE_COLLECT,
-} from "../firebase";
+import { auth, db, DB_GROUP_COLLECT, DB_RIDE_COLLECT } from "../firebase";
 import { useNavigate, useParams } from "react-router-dom";
 import { ref, set, get, query } from "firebase/database";
 import { defaultMapCenter } from "./RidePage";
@@ -35,14 +29,7 @@ const createRide = async (ride: Ride, groupId: string) => {
     /* TODO: increment id */
     throw new Error("Group ID already exists");
   }
-  await set(ref(db, `${DB_RIDE_COLLECT}/${ride.id}`), ride);
-  await set(
-    ref(
-      db,
-      `${DB_GROUP_COLLECT}/${groupId}/${DB_GROUP_RIDES_FIELD}/${ride.id}`
-    ),
-    true
-  );
+  await set(ref(db, `${DB_RIDE_COLLECT}/${groupId}/${ride.id}`), ride);
   return ride;
 };
 

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -11,7 +11,7 @@ import {
 import { useNavigate, useParams } from "react-router-dom";
 import { db } from "../firebase";
 import { equalTo, orderByChild, query, ref } from "firebase/database";
-import { Group } from "./GroupsListPage";
+import { Group } from "./CreateGroup";
 import { Val } from "react-firebase-hooks/database/dist/database/types";
 import { useList, useObjectVal } from "react-firebase-hooks/database";
 

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react";
 import { useNavigate, useParams } from "react-router-dom";
 import { db, DB_RIDE_COLLECT } from "../firebase";
-import { equalTo, orderByKey, query, ref } from "firebase/database";
+import { ref } from "firebase/database";
 import { Group } from "./CreateGroup";
 import { Val } from "react-firebase-hooks/database/dist/database/types";
 import { useList, useObjectVal } from "react-firebase-hooks/database";
@@ -44,7 +44,7 @@ export default function GroupPage() {
 const SingleGroup = ({ group }: { group: Val<Group> }) => {
   const navigate = useNavigate();
   const [snapshots, loading, error] = useList(
-    query(ref(db, DB_RIDE_COLLECT), orderByKey(), equalTo(group.id))
+    ref(db, `${DB_RIDE_COLLECT}/${group.id}`)
   );
 
   return (

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -9,8 +9,8 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { useNavigate, useParams } from "react-router-dom";
-import { db } from "../firebase";
-import { equalTo, orderByChild, query, ref } from "firebase/database";
+import { db, DB_RIDE_COLLECT } from "../firebase";
+import { equalTo, orderByKey, query, ref } from "firebase/database";
 import { Group } from "./CreateGroup";
 import { Val } from "react-firebase-hooks/database/dist/database/types";
 import { useList, useObjectVal } from "react-firebase-hooks/database";
@@ -44,7 +44,7 @@ export default function GroupPage() {
 const SingleGroup = ({ group }: { group: Val<Group> }) => {
   const navigate = useNavigate();
   const [snapshots, loading, error] = useList(
-    query(ref(db, "rides"), orderByChild("groupId"), equalTo(group.id))
+    query(ref(db, DB_RIDE_COLLECT), orderByKey(), equalTo(group.id))
   );
 
   return (

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -61,7 +61,7 @@ const SingleGroup = ({ group }: { group: Val<Group> }) => {
               navigate(`/ride/${v.key}`);
             }}
           >
-            {v.val().title}
+            {v.val().name}
           </Button>
         ))}
       <Button

--- a/frontend/src/pages/GroupsListPage.tsx
+++ b/frontend/src/pages/GroupsListPage.tsx
@@ -15,13 +15,7 @@ import { useNavigate } from "react-router-dom";
 import { auth, db, logout } from "../firebase";
 import { ref } from "firebase/database";
 import { useListVals } from "react-firebase-hooks/database";
-
-export type Group = {
-  id: string;
-  name: string;
-  rides: string[];
-  members: { [key: string]: boolean };
-};
+import { Group } from "./CreateGroup";
 
 export default function GroupsListPage() {
   const [user, loading] = useAuthState(auth);

--- a/frontend/src/pages/JoinGroup.tsx
+++ b/frontend/src/pages/JoinGroup.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Text, Box, Button, Center, Heading, Spinner } from "@chakra-ui/react";
 import { useObjectVal } from "react-firebase-hooks/database";
-import { Group } from "./GroupsListPage";
+import { Group } from "./CreateGroup";
 import { ref, set } from "firebase/database";
 import { auth, db } from "../firebase";
 import { useAuthState } from "react-firebase-hooks/auth";

--- a/frontend/src/pages/RidePage.tsx
+++ b/frontend/src/pages/RidePage.tsx
@@ -9,6 +9,7 @@ import { latLng, LatLng } from "leaflet";
 import { icon } from "leaflet";
 import startIconImg from "../images/Arrow Circle Up_8.png";
 import endIconImg from "../images/Arrow Circle Down_8.png";
+import { Ride } from "./CreateRide";
 
 const mapBoxAccessToken =
   "pk.eyJ1IjoibWFyY3VzZHVubiIsImEiOiJja3ppeTllOTAxanBuMm9uMnRwMHZ1dmF6In0.gHleMGVyUBmw_na8Elfzdg";
@@ -65,12 +66,6 @@ function ChangeView({ center, zoom }: MapView) {
 function findMidpoint(a: LatLng, b: LatLng) {
   return latLng((a.lat + b.lat) / 2, (a.lng + b.lng) / 2);
 }
-
-export type Ride = {
-  title: string;
-  start: [number, number];
-  end: [number, number];
-};
 
 type MapView = {
   center: LatLng;


### PR DESCRIPTION
When a Group or Ride is created it is stored under an id based on its title:
- `Erin's Surfer Group => erins-surfer-group`
- `Tofino Weekend => tofino-weekend`

During Ride creation they are stored under their Group's `rides` sub-collection and users are redirected to the Group page, not the Ride page.

Database Types are refactored to be in their respective `Create<Type>.tsx` and imported elsewhere.

Closes #51 and #38.