### PR TITLE
Fix map error (#46)

### DIFF
--- a/frontend/src/pages/CreateRide.tsx
+++ b/frontend/src/pages/CreateRide.tsx
@@ -54,11 +54,14 @@ const CreateRide = () => {
 
   const [startPosition, setStartPosition] = useState<[number, number]>([0, 0]);
   const [endPosition, setEndPosition] = useState<[number, number]>([0, 0]);
+  const [hasDragged, setHasDragged] = useState(false);
+
   function onDragStart(position: L.LatLng) {
     setStartPosition([position.lat, position.lng]);
   }
   function onDragEnd(position: L.LatLng) {
     setEndPosition([position.lat, position.lng]);
+    setHasDragged(true); // enable 'Create' button after user move the icon
   }
 
   const navigate = useNavigate();
@@ -86,6 +89,7 @@ const CreateRide = () => {
           isInvalid={invalidTitle}
         />
         <Button
+          disabled={!hasDragged}
           onClick={() => {
             if (groupId) {
               const ride = {


### PR DESCRIPTION
Simple fix for map error. If the user doesn't move the destination icon on Create Ride page, they can't click 'create' button so that they don't end up with (0,0) coordinate as their destination 
Resolves #46 