### PR TITLE
Fix macOS Monterey obscure bugs

### DIFF
--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -15,20 +15,25 @@
   },
   "emulators": {
     "auth": {
-      "port": 9099
+      "port": 9099,
+      "host": "127.0.0.1"
     },
     "database": {
-      "port": 9000
+      "port": 9000,
+      "host": "127.0.0.1"
     },
     "hosting": {
-      "port": 5000
+      "port": 5001,
+      "host": "127.0.0.1"
     },
     "storage": {
-      "port": 9199
+      "port": 9199,
+      "host": "127.0.0.1"
     },
     "ui": {
       "enabled": true,
-      "port": 3001
+      "port": 3001,
+      "host": "127.0.0.1"
     }
   },
   "storage": {


### PR DESCRIPTION
Fixing some very obscure issues that only affect macOS Monterey when running Node 17 and firebase emulators that took me a while to figure out.

Summary: the latest version of macOS rewrites localhost to ipv6 address `::1` instead of `127.0.0.1` as it has always been, and firebase emulators don't expect that and timeout waiting for their requested ports. Also macOS now uses port 5000 for AirPlay despite its popular use by developer tools.

Further reading: [Firebase Localhost Issue](https://github.com/firebase/firebase-tools/issues/2379) and [macOS port issue](https://chrishannah.me/monterey-blocking-ports-5000-and-7000/)