### PR TITLE
Premium groups

### DIFF
--- a/frontend/src/components/GroupCapacity.tsx
+++ b/frontend/src/components/GroupCapacity.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { Group } from "../firebase/database";
+import { Text } from "@chakra-ui/react";
+
+const GroupCapacity = (props: { group: Group }) => {
+  return (
+    <Text>
+      {Object.keys(props.group.members).length} / {props.group.maxSize}
+    </Text>
+  );
+};
+
+export default GroupCapacity;

--- a/frontend/src/components/GroupJoinButton.tsx
+++ b/frontend/src/components/GroupJoinButton.tsx
@@ -10,6 +10,10 @@ const GroupJoinButton = (props: {
   const navigate = useNavigate();
   return (
     <Button
+      isDisabled={
+        // People cannot join full groups
+        Object.keys(props.group.members).length >= props.group.maxSize
+      }
       onClick={() => {
         if (props.userId === undefined) return;
         setGroupMember(props.group.id, props.userId).then(() => {

--- a/frontend/src/components/GroupMembersList.tsx
+++ b/frontend/src/components/GroupMembersList.tsx
@@ -12,6 +12,8 @@ import {
   Icon,
   Badge,
   HStack,
+  DrawerHeader,
+  Text,
 } from "@chakra-ui/react";
 import React, { useEffect } from "react";
 import { useState } from "react";
@@ -21,6 +23,7 @@ import { getUser, User } from "../firebase/database";
 const GroupMembersList = (props: {
   members: { [key: string]: boolean };
   ownerId: string | undefined;
+  maxSize: number;
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [groupMembers, setGroupMembers] = useState<User[]>();
@@ -50,6 +53,10 @@ const GroupMembersList = (props: {
         <DrawerOverlay />
         <DrawerContent>
           <DrawerCloseButton />
+          <DrawerHeader>Group Members</DrawerHeader>
+          <Text pl={5}>
+            {Object.keys(props.members).length} / {props.maxSize}
+          </Text>
 
           <DrawerBody>
             {groupMembers?.map((user: User, i) => (

--- a/frontend/src/components/GroupSearch.tsx
+++ b/frontend/src/components/GroupSearch.tsx
@@ -22,6 +22,7 @@ import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "../firebase/firebase";
 import { useState } from "react";
 import { Group } from "../firebase/database";
+import GroupCapacity from "./GroupCapacity";
 
 const GroupSearch = (props: { groups: Group[] }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -73,6 +74,7 @@ const GroupSearch = (props: { groups: Group[] }) => {
                     <HStack key={i} w="full">
                       <Heading size="sm">{publicGroup.name}</Heading>
                       <Spacer />
+                      <GroupCapacity group={publicGroup} />
                       <GroupJoinButton group={publicGroup} userId={user?.uid} />
                     </HStack>
                   );

--- a/frontend/src/components/GroupSettings.tsx
+++ b/frontend/src/components/GroupSettings.tsx
@@ -1,0 +1,64 @@
+import { IoMdSettings } from "react-icons/all";
+import {
+  useDisclosure,
+  IconButton,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  Button,
+  ModalFooter,
+} from "@chakra-ui/react";
+import * as React from "react";
+import { useState, useEffect } from "react";
+import GroupSizeSlider from "./GroupSizeSlider";
+import { Group, setGroup } from "../firebase/database";
+
+const GroupSettings = (props: { group: Group }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [maxSize, setSize] = useState<number>(props.group.maxSize);
+  return (
+    <>
+      <IconButton
+        size="sm"
+        icon={<IoMdSettings />}
+        onClick={() => {
+          onOpen();
+        }}
+        aria-label="Share group"
+      />
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Settings</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <GroupSizeSlider
+              maxSize={maxSize}
+              isPrivate={props.group.isPrivate}
+              setSize={setSize}
+            />
+          </ModalBody>
+
+          <ModalFooter>
+            <Button
+              colorScheme="blue"
+              mr={3}
+              onClick={() => {
+                onClose();
+                setGroup({ ...props.group, maxSize });
+              }}
+            >
+              Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default GroupSettings;

--- a/frontend/src/components/GroupSettings.tsx
+++ b/frontend/src/components/GroupSettings.tsx
@@ -12,7 +12,7 @@ import {
   ModalFooter,
 } from "@chakra-ui/react";
 import * as React from "react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import GroupSizeSlider from "./GroupSizeSlider";
 import { Group, setGroup } from "../firebase/database";
 

--- a/frontend/src/components/GroupSizeSlider.tsx
+++ b/frontend/src/components/GroupSizeSlider.tsx
@@ -1,0 +1,28 @@
+import {
+  Slider,
+  SliderTrack,
+  SliderFilledTrack,
+  SliderThumb,
+  Box,
+} from "@chakra-ui/react";
+import * as React from "react";
+import { MdGraphicEq } from "react-icons/md";
+import { lightTheme } from "../theme/colours";
+
+const GroupSizeSlider = (props: {
+  maxSize: number;
+  setSize: (size: number) => void;
+}) => {
+  return (
+    <Slider aria-label="group-size" defaultValue={10} value={props.maxSize}>
+      <SliderTrack bg={lightTheme.lightButton}>
+        <SliderFilledTrack bg={lightTheme.darkButton} />
+      </SliderTrack>
+      <SliderThumb boxSize={6}>
+        <Box color="tomato" as={MdGraphicEq} />
+      </SliderThumb>
+    </Slider>
+  );
+};
+
+export default GroupSizeSlider;

--- a/frontend/src/components/GroupSizeSlider.tsx
+++ b/frontend/src/components/GroupSizeSlider.tsx
@@ -4,24 +4,56 @@ import {
   SliderFilledTrack,
   SliderThumb,
   Box,
+  Text,
 } from "@chakra-ui/react";
 import * as React from "react";
-import { MdGraphicEq } from "react-icons/md";
+import { FaUserAlt, FaUserPlus, FaUsers } from "react-icons/all";
 import { lightTheme } from "../theme/colours";
 
 const GroupSizeSlider = (props: {
   maxSize: number;
+  isPrivate: boolean;
   setSize: (size: number) => void;
 }) => {
+  // TODO: Need to decide on real values for these.
+  const userCost = 0.5 * props.maxSize;
+  const privateCost = props.isPrivate ? 1.5 : 1.0;
+  const priceOver100 = props.isPrivate ? 0.65 : 0.45;
+  const cost = props.maxSize === 10 ? 0 : userCost * privateCost;
   return (
-    <Slider aria-label="group-size" defaultValue={10} value={props.maxSize}>
-      <SliderTrack bg={lightTheme.lightButton}>
-        <SliderFilledTrack bg={lightTheme.darkButton} />
-      </SliderTrack>
-      <SliderThumb boxSize={6}>
-        <Box color="tomato" as={MdGraphicEq} />
-      </SliderThumb>
-    </Slider>
+    <>
+      <Text>
+        Max Group Size: {props.maxSize < 100 ? props.maxSize : "100+"}
+      </Text>
+      <Slider
+        aria-label="group-size"
+        defaultValue={10}
+        value={props.maxSize}
+        min={10}
+        step={10}
+        onChange={(value) => props.setSize(value)}
+      >
+        <SliderTrack bg={lightTheme.lightButton}>
+          <SliderFilledTrack bg={lightTheme.darkButton} />
+        </SliderTrack>
+        <SliderThumb boxSize={6}>
+          <Box
+            color={lightTheme.darkButton}
+            as={
+              props.maxSize === 10
+                ? FaUserAlt
+                : props.maxSize < 50
+                ? FaUserPlus
+                : FaUsers
+            }
+            size={12}
+          />
+        </SliderThumb>
+      </Slider>
+      <Text>
+        Cost: ${props.maxSize < 100 ? cost : `${priceOver100} per person`}
+      </Text>
+    </>
   );
 };
 

--- a/frontend/src/firebase/database.tsx
+++ b/frontend/src/firebase/database.tsx
@@ -45,6 +45,7 @@ export type Group = {
   rides: { [key: string]: boolean };
   members: { [key: string]: boolean };
   owner: string;
+  maxSize: number;
   banner?: string;
 };
 

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -137,6 +137,7 @@ const CreateGroup = () => {
                     rides: {},
                     members: {},
                     owner: user?.uid,
+                    maxSize,
                   },
                   user.uid
                 ).then((group) => {

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -25,6 +25,7 @@ import Header from "../components/Header";
 import DropZone, { storage } from "../firebase/storage";
 import { uploadBytes } from "firebase/storage";
 import { ref as storRef } from "firebase/storage";
+import GroupSizeSlider from "../components/GroupSizeSlider";
 
 type ValidatableFiled<T> = {
   field: T;
@@ -67,6 +68,7 @@ const CreateGroup = () => {
   });
   const [description, setDescription] = useState("");
   const [isPrivate, setPrivate] = useState<boolean>(true);
+  const [maxSize, setSize] = useState<number>(10);
 
   const isInvalidName = (name: string) => name.length === 0;
   const navigate = useNavigate();
@@ -110,6 +112,10 @@ const CreateGroup = () => {
               onInput={(e) => setDescription(e.currentTarget.value)}
               isInvalid={invalidName}
             />
+          </HStack>
+          <HStack>
+            <Text mb={"8px"}>Group Size:</Text>
+            <GroupSizeSlider setSize={setSize} maxSize={maxSize} />
           </HStack>
           <HStack>
             <Text mb={"8px"}>Private Group:</Text>

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -113,10 +113,11 @@ const CreateGroup = () => {
               isInvalid={invalidName}
             />
           </HStack>
-          <HStack>
-            <Text mb={"8px"}>Group Size:</Text>
-            <GroupSizeSlider setSize={setSize} maxSize={maxSize} />
-          </HStack>
+          <GroupSizeSlider
+            setSize={setSize}
+            isPrivate={isPrivate}
+            maxSize={maxSize}
+          />
           <HStack>
             <Text mb={"8px"}>Private Group:</Text>
             <Checkbox

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -22,6 +22,7 @@ import { ref as storageRef } from "firebase/storage";
 import ShareLink from "../components/ShareLink";
 import GroupMembersList from "../components/GroupMembersList";
 import { GroupChat } from "../components/Chat";
+import GroupSettings from "../components/GroupSettings";
 
 export default function GroupPage() {
   const navigate = useNavigate();
@@ -74,6 +75,7 @@ const SingleGroup = ({ group }: { group: Val<Group> }) => {
             <Heading textAlign={"center"}>{group.name}</Heading>
             <ShareLink />
             <GroupMembersList members={group.members} ownerId={group.owner} />
+            <GroupSettings group={group} />
           </HStack>
           <Box bg="white" px={5} py={5} borderRadius={"4px"}>
             <Text> Description: </Text>

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -74,7 +74,11 @@ const SingleGroup = ({ group }: { group: Val<Group> }) => {
           <HStack>
             <Heading textAlign={"center"}>{group.name}</Heading>
             <ShareLink />
-            <GroupMembersList members={group.members} ownerId={group.owner} />
+            <GroupMembersList
+              members={group.members}
+              ownerId={group.owner}
+              maxSize={group.maxSize}
+            />
             <GroupSettings group={group} />
           </HStack>
           <Box bg="white" px={5} py={5} borderRadius={"4px"}>

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -23,6 +23,8 @@ import ShareLink from "../components/ShareLink";
 import GroupMembersList from "../components/GroupMembersList";
 import { GroupChat } from "../components/Chat";
 import GroupSettings from "../components/GroupSettings";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { auth } from "../firebase/firebase";
 
 export default function GroupPage() {
   const navigate = useNavigate();
@@ -56,6 +58,7 @@ const SingleGroup = ({ group }: { group: Val<Group> }) => {
   const [banner, bannerLoading] = group.banner
     ? useDownloadURL(bannerRef)
     : [undefined, false];
+  const [user] = useAuthState(auth);
 
   return (
     <>
@@ -79,7 +82,7 @@ const SingleGroup = ({ group }: { group: Val<Group> }) => {
               ownerId={group.owner}
               maxSize={group.maxSize}
             />
-            <GroupSettings group={group} />
+            {group.owner === user?.uid ? <GroupSettings group={group} /> : null}
           </HStack>
           <Box bg="white" px={5} py={5} borderRadius={"4px"}>
             <Text> Description: </Text>


### PR DESCRIPTION
Adding a slider to the `CreateGroup` page to set the maximum number of people in a group.
- When viewing groups on the `GroupList` modal you can see how full they are.
- Groups that are full cannot be joined
- Added a settings page to groups where owners can edit the member capacity of their group.
Resolves #91 