### PR TITLE
Easy add car

### DIFF
--- a/frontend/src/components/ChooseCar.tsx
+++ b/frontend/src/components/ChooseCar.tsx
@@ -1,4 +1,4 @@
-import { Button, Menu, MenuItem, Select, Spinner } from "@chakra-ui/react";
+import { Menu, Select, Spinner } from "@chakra-ui/react";
 import * as React from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { useUserVehicles, Vehicle } from "../firebase/database";

--- a/frontend/src/components/ChooseCar.tsx
+++ b/frontend/src/components/ChooseCar.tsx
@@ -1,8 +1,9 @@
-import { Select, Spinner } from "@chakra-ui/react";
+import { Button, Menu, MenuItem, Select, Spinner } from "@chakra-ui/react";
 import * as React from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { useUserVehicles, Vehicle } from "../firebase/database";
 import { auth } from "../firebase/firebase";
+import AddCar from "./AddCar";
 
 const ChooseCar = (props: {
   carUpdate: (car: Vehicle) => void;
@@ -10,9 +11,14 @@ const ChooseCar = (props: {
 }) => {
   const [user] = useAuthState(auth);
   const [cars, loadingCars] = useUserVehicles(user?.uid);
+  if (!user) return null;
 
   return loadingCars ? (
     <Spinner />
+  ) : !cars || cars.length == 0 ? (
+    <Menu>
+      <AddCar user={user} />
+    </Menu>
   ) : (
     <Select
       onChange={(e) => {

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -9,6 +9,7 @@ import {
   HStack,
   Textarea,
   Checkbox,
+  Tooltip,
 } from "@chakra-ui/react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "../firebase/firebase";
@@ -120,7 +121,12 @@ const CreateGroup = () => {
             maxSize={maxSize}
           />
           <HStack>
-            <Text mb={"8px"}>Private Group:</Text>
+            <Tooltip
+              label="Private groups are only joinable through an invite link from a group member"
+              hasArrow
+            >
+              <Text mb={"8px"}>Private Group:</Text>
+            </Tooltip>
             <Checkbox
               isChecked={isPrivate}
               onChange={(e) => setPrivate(e.target.checked)}

--- a/frontend/src/pages/CreateRide.tsx
+++ b/frontend/src/pages/CreateRide.tsx
@@ -31,6 +31,7 @@ import { LatLng, latLngBounds } from "leaflet";
 import ChooseCar from "../components/ChooseCar";
 import CarStatsSlider from "../components/CarStatsSlider";
 import { getReverseGeocode, getRideRoute } from "../Directions";
+import { lightTheme } from "../theme/colours";
 
 const createRide = async (
   ride: Ride,
@@ -160,6 +161,7 @@ const CreateRide = () => {
         >
           <Button
             variant={"solid"}
+            bg={!isValidRide ? "grey.100" : lightTheme.lightButton}
             mt={4}
             mb={4}
             disabled={!isValidRide}


### PR DESCRIPTION
Fixing several minor issues from user feedback.
The "submit" button on the create ride page now switched from grey to blue when all required information is provided.
The "select car" select component now provides a quick link to add a car if they don't have any. This doesn't look great but it's better than nothing.
Adding helptext to explain what a private group is.
Resolves #202 