### PR TITLE
Better context for share links

### DIFF
--- a/frontend/src/components/Groups/ShareLink.tsx
+++ b/frontend/src/components/Groups/ShareLink.tsx
@@ -15,11 +15,13 @@ import {
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { CheckIcon, CopyIcon, ExternalLinkIcon } from "@chakra-ui/icons";
+import { User } from "firebase/auth";
 
-const ShareLink = () => {
+const ShareLink = (props: { user: User | null | undefined }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [value, setValue] = useState("Hello world");
-  const { hasCopied, onCopy } = useClipboard(value);
+  const [value, setValue] = useState("");
+  const context = `${props.user?.displayName} invited you to join their Tandem group! Follow the link to join the group: `;
+  const { hasCopied, onCopy } = useClipboard(context + value);
   const url = window.location.href;
   return (
     <>

--- a/frontend/src/components/Groups/ShareLink.tsx
+++ b/frontend/src/components/Groups/ShareLink.tsx
@@ -20,7 +20,7 @@ import { User } from "firebase/auth";
 const ShareLink = (props: { user: User | null | undefined }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [value, setValue] = useState("");
-  const context = `${props.user?.displayName} invited you to join their Tandem group! Follow the link to join the group: `;
+  const context = `${props.user?.displayName} invited you to join their Tandem group! Follow the link to join the group: \n`;
   const { hasCopied, onCopy } = useClipboard(context + value);
   const url = window.location.href;
   return (

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -68,7 +68,7 @@ const SingleGroup = ({ group }: { group: Val<Group> }) => {
       <Container>
         <VStack spacing="24px" align="c">
           <HStack pt={5}>
-            <ShareLink />
+            <ShareLink user={user} />
             <GroupDrawer
               members={group.members}
               ownerId={group.owner}


### PR DESCRIPTION
Adding a message such as "Cobey Hollier invited you to join their Tandem group! Follow the link to join the group: http://localhost:3000/group/public-chatting/join" when you click the "Share Link" button.
Sorry @samanthamhill but we cannot support emojis.
Resolves #212 