### PR TITLE
Route to store boundingBox and RideCard to display

### DIFF
--- a/frontend/src/Directions.tsx
+++ b/frontend/src/Directions.tsx
@@ -26,7 +26,7 @@ export const getRideRoute = async (start: LatLng, end: LatLng) => {
         (result) => {
           const route: Route = {
             distance: result.route.distance,
-            fuelUsed: result.route.fuelUsed,
+            boundingBox: result.route.boundingBox,
             shape: arrayToLatLngs(result.route.shape.shapePoints),
           };
           resolve(route);
@@ -46,7 +46,7 @@ export const getOptimizedRoute = async (points: LatLng[]) => {
   };
 
   return new Promise<Route>((resolve, reject) => {
-    let distance: number, fuelUsed: number;
+    let distance: number;
     /**
      * Here we are making the API call to the Directions API Optimized
      * Route endpoint, then we compose the reponse to JSON.
@@ -66,7 +66,6 @@ export const getOptimizedRoute = async (points: LatLng[]) => {
       .then((res) => res.json())
       .then((res) => {
         distance = res.route.distance;
-        fuelUsed = res.route.fuelUsed;
         return res;
       })
       .then((res) =>
@@ -82,7 +81,7 @@ export const getOptimizedRoute = async (points: LatLng[]) => {
         (res) => {
           const route: Route = {
             distance: distance,
-            fuelUsed: fuelUsed,
+            boundingBox: res.route.boundingBox,
             shape: arrayToLatLngs(res.route.shape.shapePoints),
           };
           resolve(route);

--- a/frontend/src/components/Rides/RideCard.tsx
+++ b/frontend/src/components/Rides/RideCard.tsx
@@ -95,14 +95,26 @@ export default function RideCard({
           <Collapse
             in={isOpen}
             onAnimationComplete={() => {
-              if (map && isOpen) {
+              if (map && ride && route && isOpen) {
                 map.invalidateSize();
-                map.fitBounds(
-                  latLngBounds([
-                    latLng(ride.end.lat, ride.end.lng),
-                    startLocation,
-                  ]).pad(0.1)
-                );
+                const box = route?.boundingBox
+                  ? [
+                      latLng(
+                        route.boundingBox.ul.lat,
+                        route.boundingBox.ul.lng
+                      ),
+                      latLng(
+                        route.boundingBox.lr.lat,
+                        route.boundingBox.lr.lng
+                      ),
+                    ]
+                  : [
+                      latLng(ride.end.lat, ride.end.lng),
+                      ...Object.values(ride.pickupPoints).map((p) => {
+                        return latLng(p.location.lat, p.location.lng);
+                      }),
+                    ];
+                map.fitBounds(latLngBounds(box).pad(0.1));
               }
             }}
           >

--- a/frontend/src/firebase/database.tsx
+++ b/frontend/src/firebase/database.tsx
@@ -83,7 +83,10 @@ export type Ride = {
 
 export type Route = {
   distance: number;
-  fuelUsed: number;
+  boundingBox: {
+    ul: { lat: number; lng: number };
+    lr: { lat: number; lng: number };
+  };
   shape: LatLng[];
 };
 


### PR DESCRIPTION
Changes Routes to store ideal bounding box and no longer store MapQuest fuelUsed estimate.

RideCards now use the route bounding box, or falls back to the bounds that contain all Pickup Points and Destination.

<img width="370" alt="image" src="https://user-images.githubusercontent.com/43759986/158751614-d4605e8a-ef14-4949-86b1-f8e9b8e36b83.png"> <img width="370" alt="image" src="https://user-images.githubusercontent.com/43759986/158751678-0da99cd1-5721-4ee7-b4cc-f7fc53b31e3d.png">

Closes #175 