### PR TITLE
217 profile icons instead of pictures

### DIFF
--- a/frontend/src/components/Groups/IconBrowser.tsx
+++ b/frontend/src/components/Groups/IconBrowser.tsx
@@ -1,0 +1,44 @@
+import { Box, Button, HStack, Icon, SimpleGrid } from "@chakra-ui/react";
+import React, { useState } from "react";
+import { IconType } from "react-icons";
+import * as icons from "react-icons/gi";
+
+const IconBrowser = () => {
+  const [startIndx, setStartIndx] = useState<number>(0);
+  const numPerPage = 25;
+  return (
+    <Box p={5}>
+      <SimpleGrid columns={5} spacing={5}>
+        {Object.keys(icons)
+          .slice(startIndx, startIndx + 25)
+          .map((key: string) => {
+            console.log(key);
+            return (
+              <Icon
+                key={key}
+                aria-label={key}
+                w="100%"
+                h="100%"
+                as={(icons as { [k: string]: IconType })[key]}
+              />
+            );
+          })}
+      </SimpleGrid>
+      <HStack alignItems="center" pt={5}>
+        <Button
+          isDisabled={startIndx < numPerPage}
+          onClick={() => setStartIndx(startIndx - numPerPage)}
+        >
+          Prev
+        </Button>
+        <Button
+          isDisabled={startIndx + numPerPage + 1 > Object.keys(icons).length}
+          onClick={() => setStartIndx(startIndx + numPerPage)}
+        >
+          Next
+        </Button>
+      </HStack>
+    </Box>
+  );
+};
+export default IconBrowser;

--- a/frontend/src/components/Groups/IconBrowser.tsx
+++ b/frontend/src/components/Groups/IconBrowser.tsx
@@ -2,23 +2,46 @@ import {
   Button,
   HStack,
   IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
   SimpleGrid,
   VStack,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { IconType } from "react-icons";
 import * as icons from "react-icons/gi";
+import { ImSearch } from "react-icons/im";
+import { styleColors } from "../../theme/colours";
 
 const IconBrowser = (props: {
   icon: string;
   updateIcon: (icon: string) => void;
 }) => {
   const [startIndx, setStartIndx] = useState<number>(0);
+  const [searchInput, setSearchInput] = useState("");
   const numPerPage = 25;
   return (
     <VStack py={5} alignItems="center" spacing={3} w="100%">
+      <InputGroup>
+        <Input
+          onChange={(e) => {
+            setSearchInput(e.currentTarget.value);
+            setStartIndx(0);
+          }}
+        />
+        <InputLeftElement>
+          <ImSearch color={styleColors.deepBlue} />
+        </InputLeftElement>
+      </InputGroup>
+
       <SimpleGrid columns={5} spacing={5} w="100%">
         {Object.keys(icons)
+          .filter((key: string) =>
+            key
+              .toLowerCase()
+              .includes(searchInput.toLowerCase().replace(/\s+/g, ""))
+          )
           .slice(startIndx, startIndx + 25)
           .map((key: string) => {
             return (
@@ -27,6 +50,9 @@ const IconBrowser = (props: {
                 aria-label={key}
                 w="100%"
                 h="100%"
+                bg={
+                  key == props.icon ? styleColors.mint : styleColors.lightBlue
+                }
                 as={(icons as { [k: string]: IconType })[key]}
                 isRound
                 p={1}

--- a/frontend/src/components/Groups/IconBrowser.tsx
+++ b/frontend/src/components/Groups/IconBrowser.tsx
@@ -1,25 +1,38 @@
-import { Box, Button, HStack, Icon, SimpleGrid } from "@chakra-ui/react";
+import {
+  Button,
+  HStack,
+  IconButton,
+  SimpleGrid,
+  VStack,
+} from "@chakra-ui/react";
 import React, { useState } from "react";
 import { IconType } from "react-icons";
 import * as icons from "react-icons/gi";
 
-const IconBrowser = () => {
+const IconBrowser = (props: {
+  icon: string;
+  updateIcon: (icon: string) => void;
+}) => {
   const [startIndx, setStartIndx] = useState<number>(0);
   const numPerPage = 25;
   return (
-    <Box p={5}>
-      <SimpleGrid columns={5} spacing={5}>
+    <VStack py={5} alignItems="center" spacing={3} w="100%">
+      <SimpleGrid columns={5} spacing={5} w="100%">
         {Object.keys(icons)
           .slice(startIndx, startIndx + 25)
           .map((key: string) => {
-            console.log(key);
             return (
-              <Icon
+              <IconButton
                 key={key}
                 aria-label={key}
                 w="100%"
                 h="100%"
                 as={(icons as { [k: string]: IconType })[key]}
+                isRound
+                p={1}
+                onClick={() => {
+                  props.updateIcon(key);
+                }}
               />
             );
           })}
@@ -38,7 +51,7 @@ const IconBrowser = () => {
           Next
         </Button>
       </HStack>
-    </Box>
+    </VStack>
   );
 };
 export default IconBrowser;

--- a/frontend/src/components/Groups/IconBrowser.tsx
+++ b/frontend/src/components/Groups/IconBrowser.tsx
@@ -21,6 +21,9 @@ const IconBrowser = (props: {
   const [startIndx, setStartIndx] = useState<number>(0);
   const [searchInput, setSearchInput] = useState("");
   const numPerPage = 25;
+  const filteredIcons = Object.keys(icons).filter((key: string) =>
+    key.toLowerCase().includes(searchInput.toLowerCase().replace(/\s+/g, ""))
+  );
   return (
     <VStack py={5} alignItems="center" spacing={3} w="100%">
       <InputGroup>
@@ -36,32 +39,23 @@ const IconBrowser = (props: {
       </InputGroup>
 
       <SimpleGrid columns={5} spacing={5} w="100%">
-        {Object.keys(icons)
-          .filter((key: string) =>
-            key
-              .toLowerCase()
-              .includes(searchInput.toLowerCase().replace(/\s+/g, ""))
-          )
-          .slice(startIndx, startIndx + 25)
-          .map((key: string) => {
-            return (
-              <IconButton
-                key={key}
-                aria-label={key}
-                w="100%"
-                h="100%"
-                bg={
-                  key == props.icon ? styleColors.mint : styleColors.lightBlue
-                }
-                as={(icons as { [k: string]: IconType })[key]}
-                isRound
-                p={1}
-                onClick={() => {
-                  props.updateIcon(key);
-                }}
-              />
-            );
-          })}
+        {filteredIcons.slice(startIndx, startIndx + 25).map((key: string) => {
+          return (
+            <IconButton
+              key={key}
+              aria-label={key}
+              w="100%"
+              h="100%"
+              bg={key == props.icon ? styleColors.mint : styleColors.lightBlue}
+              as={(icons as { [k: string]: IconType })[key]}
+              isRound
+              p={1}
+              onClick={() => {
+                props.updateIcon(key);
+              }}
+            />
+          );
+        })}
       </SimpleGrid>
       <HStack alignItems="center" pt={5}>
         <Button
@@ -71,7 +65,7 @@ const IconBrowser = (props: {
           Prev
         </Button>
         <Button
-          isDisabled={startIndx + numPerPage + 1 > Object.keys(icons).length}
+          isDisabled={startIndx + numPerPage + 1 > filteredIcons.length}
           onClick={() => setStartIndx(startIndx + numPerPage)}
         >
           Next

--- a/frontend/src/components/VerifiedStep.tsx
+++ b/frontend/src/components/VerifiedStep.tsx
@@ -51,6 +51,7 @@ const VerifiedStep = <T,>({
           size="sm"
           onClick={() => nextStep(currentInput)}
           isDisabled={!verified}
+          mb={4}
         >
           {isLastStep ? "Submit" : "Next"}
         </Button>

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -95,7 +95,7 @@ const CreateGroup = () => {
   });
   const [description, setDescription] = useState("");
   const [isPrivate, setPrivate] = useState<boolean>(true);
-  const [plan, setPlan] = useState<PlanTypes>();
+  const [plan, setPlan] = useState<PlanTypes>("Friend Group");
   const MAX_GROUP_NAME_LENGTH = 25;
 
   const isInvalidName = (name: string) => name.length === 0;
@@ -216,7 +216,7 @@ const CreateGroup = () => {
             icon={IoMdPhotos}
             isLastStep={true}
           >
-            <VStack align="center" height="100%" width="100%">
+            <VStack align="center" height="100%" width="100%" p={4} spacing={4}>
               <Heading size="md"> Upload Banner</Heading>
               <FileDropzone parentCallback={handleCallback} />
               <Heading size="md"> Upload Profile Picture</Heading>
@@ -229,7 +229,7 @@ const CreateGroup = () => {
                   <TabPanels>
                     <TabPanel>
                       <FileDropzone parentCallback={handleProfilePicSubmit} />
-                      <Box py={120}></Box>
+                      <Box py={149}></Box>
                     </TabPanel>
                     <TabPanel>
                       <IconBrowser

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -73,6 +73,7 @@ const CreateGroup = () => {
   // TODO: Fix type
   const [banner, setBanner] = useState<Blob | MediaSource>();
   const [profilePic, setProfilePic] = useState<Blob | MediaSource>();
+  const [chosenIcon, setChosenIcon] = useState("");
 
   const handleCallback = (childBanner: Blob | MediaSource) => {
     setBanner(childBanner);
@@ -126,6 +127,8 @@ const CreateGroup = () => {
               setGroupProfilePic(group.id, url?.fullPath);
             }
           );
+        } else if (chosenIcon && chosenIcon.length > 0) {
+          setGroupProfilePic(group.id, chosenIcon);
         }
       });
     }
@@ -229,7 +232,10 @@ const CreateGroup = () => {
                       <Box py={120}></Box>
                     </TabPanel>
                     <TabPanel>
-                      <IconBrowser />
+                      <IconBrowser
+                        icon={chosenIcon}
+                        updateIcon={setChosenIcon}
+                      />
                     </TabPanel>
                   </TabPanels>
                 </Tabs>

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -9,6 +9,13 @@ import {
   Checkbox,
   Tooltip,
   Container,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Tab,
+  VStack,
+  Box,
 } from "@chakra-ui/react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "../firebase/firebase";
@@ -36,6 +43,7 @@ import {
   ImQuill,
   IoMdPhotos,
 } from "react-icons/all";
+import IconBrowser from "../components/Groups/IconBrowser";
 
 type ValidatableFiled<T> = {
   field: T;
@@ -205,10 +213,28 @@ const CreateGroup = () => {
             icon={IoMdPhotos}
             isLastStep={true}
           >
-            <Heading size="md"> Upload Banner</Heading>
-            <FileDropzone parentCallback={handleCallback} />
-            <Heading size="md"> Upload Profile Picture</Heading>
-            <FileDropzone parentCallback={handleProfilePicSubmit} />
+            <VStack align="center" height="100%" width="100%">
+              <Heading size="md"> Upload Banner</Heading>
+              <FileDropzone parentCallback={handleCallback} />
+              <Heading size="md"> Upload Profile Picture</Heading>
+              <HStack alignItems="center">
+                <Tabs isFitted>
+                  <TabList>
+                    <Tab>Upload a profile picture</Tab>
+                    <Tab>Choose an Icon</Tab>
+                  </TabList>
+                  <TabPanels>
+                    <TabPanel>
+                      <FileDropzone parentCallback={handleProfilePicSubmit} />
+                      <Box py={120}></Box>
+                    </TabPanel>
+                    <TabPanel>
+                      <IconBrowser />
+                    </TabPanel>
+                  </TabPanels>
+                </Tabs>
+              </HStack>
+            </VStack>
           </VerifiedStep>
         </Steps>
       </Container>

--- a/frontend/src/pages/GroupsListPage.tsx
+++ b/frontend/src/pages/GroupsListPage.tsx
@@ -22,6 +22,8 @@ import { Group, useGroups } from "../firebase/database";
 import { useDownloadURL } from "react-firebase-hooks/storage";
 import { ref } from "firebase/storage";
 import { storage } from "../firebase/storage";
+import * as icons from "react-icons/gi";
+import { IconType } from "react-icons";
 
 export default function GroupsListPage() {
   const [user, loading] = useAuthState(auth);
@@ -76,7 +78,8 @@ export default function GroupsListPage() {
 
 const GroupListElement = (props: { group: Group; index: number }) => {
   const navigate = useNavigate();
-  const profileRef = ref(storage, `${props.group.profilePic}`);
+  const photoName = props.group.profilePic;
+  const profileRef = ref(storage, `${photoName}`);
   const [profilePic, profilePicLoading] = useDownloadURL(profileRef);
 
   return (
@@ -86,15 +89,22 @@ const GroupListElement = (props: { group: Group; index: number }) => {
         textAlign="left"
         onClick={() => navigate(NavConstants.groupWithIdJoin(props.group.id))}
       >
-        {profilePicLoading ? null : (
+        {profilePicLoading ? null : profilePic ? (
           <Avatar
             bg={groupLogos[props.index % groupLogos.length]}
             src={profilePic}
             size="xs"
-            name={props.group.name}
+            name={photoName ? undefined : props.group.name}
             mr={4}
           />
-        )}
+        ) : photoName ? (
+          <Avatar
+            bg={groupLogos[props.index % groupLogos.length]}
+            as={(icons as { [k: string]: IconType })[photoName]}
+            size="xs"
+            mr={4}
+          />
+        ) : null}
         {props.group.name}
       </Button>
     </>


### PR DESCRIPTION
Creating this on behalf on Sam since she is busy today. 
You can now use an Icon as a profile picture instead of uploading a picture. There is a search box to help users find the right icon for their use-case.

Resolves #217 