### PR TITLE
Public Group Preview

### DIFF
--- a/frontend/src/components/Groups/GroupJoinButton.tsx
+++ b/frontend/src/components/Groups/GroupJoinButton.tsx
@@ -5,7 +5,6 @@ import {
   AlertIcon,
   AlertTitle,
   Button,
-  CloseButton,
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router";
 import { Group, setGroupMember } from "../../firebase/database";

--- a/frontend/src/components/Groups/GroupJoinButton.tsx
+++ b/frontend/src/components/Groups/GroupJoinButton.tsx
@@ -1,5 +1,12 @@
 import * as React from "react";
-import { Button } from "@chakra-ui/react";
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Button,
+  CloseButton,
+} from "@chakra-ui/react";
 import { useNavigate } from "react-router";
 import { Group, setGroupMember } from "../../firebase/database";
 import { groupMaxSize } from "../Promotional/PriceSelector";
@@ -9,22 +16,32 @@ const GroupJoinButton = (props: {
   userId: string | undefined;
 }) => {
   const navigate = useNavigate();
+  const groupIsFull = // People cannot join full groups
+    Object.keys(props.group.members).length >= groupMaxSize(props.group.plan);
+
   return (
-    <Button
-      isDisabled={
-        // People cannot join full groups
-        Object.keys(props.group.members).length >=
-        groupMaxSize(props.group.plan)
-      }
-      onClick={() => {
-        if (props.userId === undefined) return;
-        setGroupMember(props.group.id, props.userId).then(() => {
-          navigate(`/group/${props.group.id}`);
-        });
-      }}
-    >
-      Join
-    </Button>
+    <>
+      <Button
+        isDisabled={groupIsFull}
+        onClick={() => {
+          if (props.userId === undefined) return;
+          setGroupMember(props.group.id, props.userId).then(() => {
+            navigate(`/group/${props.group.id}`);
+          });
+        }}
+      >
+        Join
+      </Button>
+      {groupIsFull ? (
+        <Alert status="error">
+          <AlertIcon />
+          <AlertTitle mr={2}>This group is full!</AlertTitle>
+          <AlertDescription>
+            Ask the group administrator to upgrade their plan.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+    </>
   );
 };
 

--- a/frontend/src/components/Groups/GroupSearch.tsx
+++ b/frontend/src/components/Groups/GroupSearch.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {
+  Button,
   Heading,
   HStack,
   IconButton,
@@ -23,11 +24,13 @@ import { auth } from "../../firebase/firebase";
 import { useState } from "react";
 import { Group } from "../../firebase/database";
 import GroupCapacity from "./GroupCapacity";
+import { useNavigate } from "react-router-dom";
 
 const GroupSearch = (props: { groups: Group[] }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [search, setSearch] = useState("");
   const [user] = useAuthState(auth);
+  const navigate = useNavigate();
 
   return (
     <>
@@ -75,6 +78,13 @@ const GroupSearch = (props: { groups: Group[] }) => {
                       <Heading size="sm">{publicGroup.name}</Heading>
                       <Spacer />
                       <GroupCapacity group={publicGroup} />
+                      <Button
+                        onClick={() =>
+                          navigate(`/group/${publicGroup.id}/join`)
+                        }
+                      >
+                        Preview
+                      </Button>
                       <GroupJoinButton group={publicGroup} userId={user?.uid} />
                     </HStack>
                   );

--- a/frontend/src/components/Promotional/PriceSelector.tsx
+++ b/frontend/src/components/Promotional/PriceSelector.tsx
@@ -65,7 +65,8 @@ export const planData: PlanInfo[] = [
 
 export function groupMaxSize(groupPlan: PlanTypes) {
   return (
-    planData.find((p: PlanInfo) => p.data.name === groupPlan)?.data.limit || 0
+    planData.find((p: PlanInfo) => p.data.name === groupPlan)?.data.limit ||
+    100000
   );
 }
 

--- a/frontend/src/pages/GroupsListPage.tsx
+++ b/frontend/src/pages/GroupsListPage.tsx
@@ -41,7 +41,9 @@ export default function GroupsListPage() {
       <Header />
       <Container>
         <Center>
-          <Heading size={"md"}>My Groups</Heading>
+          <Heading size={"md"} mt={5}>
+            My Groups
+          </Heading>
         </Center>
         <GroupSearch groups={groups ?? []} />
         <Center>

--- a/frontend/src/pages/JoinGroup.tsx
+++ b/frontend/src/pages/JoinGroup.tsx
@@ -51,7 +51,7 @@ const FoundGroup = (props: GroupUserProps) => {
 
   return (
     <>
-      <Header />
+      <Header pages={[{ label: "My Groups", url: "/" }]} />
       <Box>
         <Center>
           <VStack>


### PR DESCRIPTION
Adding a button to the group search list that allows the user to see a preview of the group before joining it. Also adding a Chakra Alert to the preview page when the group is full so that users don't get confused by the disabled button.
I haven't touched the "Join Group Page" contents since that is a separate issue.
Resolves #259 