### PR TITLE
Fixing price selector width in create group

### DIFF
--- a/frontend/src/components/Promotional/PriceSelector.tsx
+++ b/frontend/src/components/Promotional/PriceSelector.tsx
@@ -94,7 +94,7 @@ const PriceSelector = (props: {
             icon={card.icon}
             highlight={card.data.name == selectedPlan}
             button={
-              card.data.name == selectedPlan || !props.showSelectors ? (
+              !props.showSelectors ? (
                 <></>
               ) : (
                 <Button
@@ -104,6 +104,7 @@ const PriceSelector = (props: {
                       props.updateGroupPlan(card.data.name);
                     }
                   }}
+                  isDisabled={card.data.name == selectedPlan}
                 >
                   Select
                 </Button>

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -137,7 +137,7 @@ const CreateGroup = () => {
   return (
     <>
       <Header pages={[{ label: "My Groups", url: "/" }]} />
-      <Container>
+      <Container maxWidth="90%">
         <Heading textAlign={"center"}>Create Group</Heading>
         <Steps activeStep={activeStep} orientation="vertical">
           <VerifiedStep


### PR DESCRIPTION
The max width of the "Create Group" page was too skinny to display the price selector. This resulted in it looking bad. I also thought that the "select" buttons disappearing when the plan was selected looked weird. It looked like this before 
![image](https://user-images.githubusercontent.com/32989729/159102683-ac50806b-5b2f-44e5-ae9d-f590dd923f4c.png)
And now it looks like this.
![image](https://user-images.githubusercontent.com/32989729/159102692-7535f570-cf59-490d-a0fe-254165b33565.png)
