### PR TITLE
Trying to make the time selection obviously not-broken

### DIFF
--- a/frontend/src/pages/CreateRide.tsx
+++ b/frontend/src/pages/CreateRide.tsx
@@ -101,6 +101,19 @@ const CreateRide = () => {
     map?.fitBounds(latLngBounds([startPosition, endPosition]));
   }
 
+  function getCurrentTime() {
+    const date = new Date();
+    const timeComponents = [date.getHours(), date.getMinutes()];
+    return timeComponents
+      .map((component) => {
+        const pad = component < 10 ? "0" : "";
+        return pad + component;
+      })
+      .join(":");
+  }
+
+  const currentTime = getCurrentTime();
+
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -258,6 +271,7 @@ const CreateRide = () => {
                 mb="4"
                 type="time"
                 onInput={(e) => setStartTime(e.currentTarget.value)}
+                defaultValue={currentTime}
               />
               <InputLeftElement>
                 <FaClock />


### PR DESCRIPTION
In user testing somebody reported that the "time selection" when creating a ride seemed broken. I made the time input default to the current time so that it's obvious what you're meant to type to edit the time.
Resolves #291 