### PR TITLE
Fixing errors on promotion, group list and group page.

### DIFF
--- a/frontend/src/components/Promotional/Quotee.tsx
+++ b/frontend/src/components/Promotional/Quotee.tsx
@@ -6,7 +6,6 @@ import { styleColors } from "../../theme/colours";
 interface Props extends BoxProps {
   name: string;
   jobTitle: string;
-  imageSrc: string;
 }
 
 export const Quotee = (props: Props) => {

--- a/frontend/src/components/Promotional/Testimonial.tsx
+++ b/frontend/src/components/Promotional/Testimonial.tsx
@@ -32,7 +32,6 @@ export const Testimonal = () => (
         <Quotee
           name="Marrie Jones"
           jobTitle="Marketing Ads Strategist"
-          imageSrc="https://images.unsplash.com/photo-1580489944761-15a19d654956?ixid=MXwxMjA3fDB8MHxzZWFyY2h8OTN8fGxhZHklMjBoZWFkc2hvdCUyMHNtaWxpbmd8ZW58MHx8MHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60"
           mt="8"
         />
       </Flex>

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -55,16 +55,20 @@ export default function GroupPage() {
 
 const SingleGroup = ({ group }: { group: Val<Group> }) => {
   const navigate = useNavigate();
-  const bannerRef = storageRef(storage, `${group.banner}`);
-  const [banner, bannerLoading] = useDownloadURL(bannerRef);
+  const bannerRef = group.banner
+    ? storageRef(storage, group.banner)
+    : undefined;
+  const [banner, bannerLoading, error] = useDownloadURL(bannerRef);
   const [user] = useAuthState(auth);
 
   return (
     <>
       <Header pages={[{ label: "My Groups", url: "/" }]} />
-      {!bannerLoading && banner !== undefined ? (
+      {bannerLoading || error ? (
+        <Box bg="blue" h="10%" w="100%" maxHeight="200px" minHeight="100" />
+      ) : (
         <Image src={banner} width="100%" maxHeight="200px" objectFit="cover" />
-      ) : null}
+      )}
       <Container>
         <VStack spacing="24px" align="c">
           <HStack pt={5}>

--- a/frontend/src/pages/GroupsListPage.tsx
+++ b/frontend/src/pages/GroupsListPage.tsx
@@ -81,7 +81,7 @@ export default function GroupsListPage() {
 const GroupListElement = (props: { group: Group; index: number }) => {
   const navigate = useNavigate();
   const photoName = props.group.profilePic;
-  const profileRef = ref(storage, `${photoName}`);
+  const profileRef = photoName ? ref(storage, `${photoName}`) : undefined;
   const [profilePic, profilePicLoading] = useDownloadURL(profileRef);
 
   return (

--- a/frontend/src/pages/GroupsListPage.tsx
+++ b/frontend/src/pages/GroupsListPage.tsx
@@ -89,7 +89,7 @@ const GroupListElement = (props: { group: Group; index: number }) => {
       <Button
         mt={4}
         textAlign="left"
-        onClick={() => navigate(NavConstants.groupWithIdJoin(props.group.id))}
+        onClick={() => navigate(NavConstants.groupWithId(props.group.id))}
       >
         {profilePicLoading ? null : profilePic ? (
           <Avatar

--- a/frontend/src/pages/GroupsListPage.tsx
+++ b/frontend/src/pages/GroupsListPage.tsx
@@ -81,7 +81,10 @@ export default function GroupsListPage() {
 const GroupListElement = (props: { group: Group; index: number }) => {
   const navigate = useNavigate();
   const photoName = props.group.profilePic;
-  const profileRef = photoName ? ref(storage, `${photoName}`) : undefined;
+  const profileRef =
+    photoName && photoName.startsWith("profilePics/")
+      ? ref(storage, `${photoName}`)
+      : undefined;
   const [profilePic, profilePicLoading] = useDownloadURL(profileRef);
 
   return (


### PR DESCRIPTION
Fixing numerous console errors on the Production, Group List, and Group pages. There are probably still errors in other components, but I fixed a bunch of the main pages.

Fixes include:
- Invalid download url refs for profile pictures
- Errors when loading icon profile pictures
- imgsrc on client testimonials
- Fixing group list navigation error

Resolves #293 