### PR TITLE
Adding help-text explaining that num-seats includes driver

### DIFF
--- a/frontend/src/components/Profiles/CarStatsSlider.tsx
+++ b/frontend/src/components/Profiles/CarStatsSlider.tsx
@@ -27,7 +27,7 @@ const CarStatsSlider = (props: {
         Number of Seats
       </Heading>
       <Text textAlign="left" variant="help-text">
-        Includes driver
+        Total number of seats including driver.
       </Text>
       <HStack>
         <Slider

--- a/frontend/src/components/Profiles/CarStatsSlider.tsx
+++ b/frontend/src/components/Profiles/CarStatsSlider.tsx
@@ -7,6 +7,7 @@ import {
   Tooltip,
   Box,
   HStack,
+  Text,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { BsQuestionCircleFill } from "react-icons/all";
@@ -22,9 +23,12 @@ const CarStatsSlider = (props: {
   const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
   return (
     <>
-      <Heading as="h2" size="l" mt={2}>
+      <Heading as="h2" size="l" mt={2} textAlign="left">
         Number of Seats
       </Heading>
+      <Text textAlign="left" variant="help-text">
+        Includes driver
+      </Text>
       <HStack>
         <Slider
           id="slider"

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -83,9 +83,11 @@ const SingleGroup = ({ group }: { group: Val<Group> }) => {
           </HStack>
 
           <Heading textAlign={"center"}>{group.name}</Heading>
-          <Box px={5} py={5} borderRadius={5} borderWidth={3}>
-            {group.description}
-          </Box>
+          {group.description && group.description.length > 0 ? (
+            <Box px={5} py={5} borderRadius={5} borderWidth={3}>
+              {group.description}
+            </Box>
+          ) : null}
           <Text>Active Rides</Text>
           {group.rides
             ? Object.keys(group.rides).map((key) => (


### PR DESCRIPTION
Simple fix adding helptext to the number of seats slider for better clarity.
I also made another simple change to hide the group description if it's empty (no box gets rendered).
Resolves #289 