### PR TITLE
Handing duplicate auth provider error

### DIFF
--- a/frontend/src/firebase/firebase.tsx
+++ b/frontend/src/firebase/firebase.tsx
@@ -67,7 +67,11 @@ export const signInWithProvider = async (
       }
     });
   } catch (err) {
-    console.error(err);
+    if (err instanceof FirebaseError) {
+      handleAuthError(err);
+    } else {
+      console.log(err);
+    }
   }
 };
 

--- a/frontend/src/firebase/firebase.tsx
+++ b/frontend/src/firebase/firebase.tsx
@@ -136,6 +136,11 @@ const handleAuthError = (error: FirebaseError) => {
       report.title = "Missing Email";
       report.description = "Please provide a valid email address.";
       break;
+    case "auth/account-exists-with-different-credential":
+      report.title = "Account Already Exists";
+      report.description =
+        "It's possible you already created an account with a different login service.";
+      break;
     default:
       report.title = error.code;
       report.description = error.message;


### PR DESCRIPTION
This should handle the error where you sign up with Google and then try to sign up with Facebook. Could somebody who has a Facebook account that is registered using a gmail address please test it? Such as @samanthamhill 
Resolves #276 