### PR TITLE
Advancing register/login pages using enter key

### DIFF
--- a/frontend/src/components/PasswordField.tsx
+++ b/frontend/src/components/PasswordField.tsx
@@ -13,6 +13,7 @@ import { styleColors } from "../theme/colours";
 const PasswordField = (props: {
   setPassword: (newPass: string) => void;
   passVariant: string;
+  submitHandler: () => void;
 }) => {
   const [showPassword, setShowPassword] = useState<boolean>(false);
   return (
@@ -23,6 +24,11 @@ const PasswordField = (props: {
           placeholder="Password"
           onChange={(event) => props.setPassword(event.currentTarget.value)}
           variant={props.passVariant}
+          onKeyDown={(ev) => {
+            if (ev.key == "Enter") {
+              props.submitHandler();
+            }
+          }}
         />
         <InputRightElement h="100%">
           <IconButton

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -94,7 +94,11 @@ export default function Login({ state }: { state?: LocationGotoState }) {
               variant="tandem-login"
             />
           </FormControl>
-          <PasswordField setPassword={setPassword} passVariant="tandem-login" />
+          <PasswordField
+            setPassword={setPassword}
+            passVariant="tandem-login"
+            submitHandler={handleEmailLogin}
+          />
 
           <Text align="right" textColor="white" width="85%" pb={5}>
             Forgot Password?{" "}

--- a/frontend/src/pages/Registration.tsx
+++ b/frontend/src/pages/Registration.tsx
@@ -105,6 +105,7 @@ function Register() {
         <PasswordField
           setPassword={setPassword}
           passVariant="tandem-registration"
+          submitHandler={register}
         />
         <Tooltip hasArrow label={tooltipContents} shouldWrapChildren>
           <Button


### PR DESCRIPTION
Simple fix that makes the "Return/Enter" key submit the form on the login and registration pages.
Resolves #313 