### PR TITLE
 Making group list float

### DIFF
--- a/frontend/src/components/Groups/GroupSelector.tsx
+++ b/frontend/src/components/Groups/GroupSelector.tsx
@@ -105,7 +105,7 @@ const GroupList = (props: { updateGroups?: (groups: Group[]) => void }) => {
       </Drawer>
     </>
   ) : (
-    <Box h="100vh" bg={styleColors.periwinkle}>
+    <Box h="100vh" bg={styleColors.periwinkle} position="fixed">
       <ListContents
         userGroups={userGroups ?? []}
         isMobile={isMobile}


### PR DESCRIPTION
Really simple fix making the group list static so that it doesn't scroll with the page.
Resolves #331 