### PR TITLE
Fixing driver joining ride without a car bug

### DIFF
--- a/frontend/src/components/Profiles/AddCar.tsx
+++ b/frontend/src/components/Profiles/AddCar.tsx
@@ -46,22 +46,35 @@ const trucks: Vehicle[] = [
   { type: "Extra Large", fuelUsage: 15, numSeats: 7 },
 ];
 
+interface AddCarProps {
+  modalProps: { isOpen: boolean; onClose(): void };
+  user: User;
+}
+
+export const AddCarModal = (props: AddCarProps) => {
+  return (
+    <Modal
+      isOpen={props.modalProps.isOpen}
+      onClose={props.modalProps.onClose}
+      isCentered={true}
+    >
+      <ModalContent h={"container.sm"} padding={"4"} w={"95%"}>
+        <ModalCloseButton />
+        <ModalHeader>Add A Car</ModalHeader>
+        <CarSelector user={props.user} onDone={props.modalProps.onClose} />
+      </ModalContent>
+    </Modal>
+  );
+};
+
 const AddCar = (props: { user: User }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
-    <MenuItem onClick={onOpen}>
-      Add A Car
-      {
-        <Modal isOpen={isOpen} onClose={onClose} isCentered={true}>
-          <ModalContent h={"container.sm"} padding={"4"} w={"95%"}>
-            <ModalCloseButton />
-            <ModalHeader>Add A Car</ModalHeader>
-            <CarSelector user={props.user} onDone={onClose} />
-          </ModalContent>
-        </Modal>
-      }
-    </MenuItem>
+    <>
+      <MenuItem onClick={onOpen}>Add A Car</MenuItem>
+      <AddCarModal user={props.user} modalProps={{ isOpen, onClose }} />
+    </>
   );
 };
 

--- a/frontend/src/components/Rides/ChooseCar.tsx
+++ b/frontend/src/components/Rides/ChooseCar.tsx
@@ -1,10 +1,10 @@
-import { Menu, Select, Spinner } from "@chakra-ui/react";
+import { Button, Flex, Select, Spinner, useDisclosure } from "@chakra-ui/react";
 import * as React from "react";
 import { useEffect } from "react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { useUserVehicles, Vehicle } from "../../firebase/database";
 import { auth } from "../../firebase/firebase";
-import AddCar from "../Profiles/AddCar";
+import { AddCarModal } from "../Profiles/AddCar";
 
 const ChooseCar = (props: {
   carUpdate: (car: Vehicle | undefined) => void;
@@ -12,6 +12,7 @@ const ChooseCar = (props: {
 }) => {
   const [user] = useAuthState(auth);
   const [cars, loadingCars] = useUserVehicles(user?.uid);
+  const { isOpen, onOpen, onClose } = useDisclosure();
   if (!user) return null;
 
   useEffect(() => {
@@ -23,9 +24,10 @@ const ChooseCar = (props: {
   return loadingCars ? (
     <Spinner />
   ) : !cars || cars.length == 0 ? (
-    <Menu>
-      <AddCar user={user} />
-    </Menu>
+    <Flex alignContent={"flex-start"}>
+      <Button onClick={onOpen}>Add a Car</Button>
+      <AddCarModal user={user} modalProps={{ isOpen, onClose }} />
+    </Flex>
   ) : (
     <Select
       value={props.carId}

--- a/frontend/src/components/Rides/RideCard.tsx
+++ b/frontend/src/components/Rides/RideCard.tsx
@@ -259,7 +259,7 @@ function DriverBar({
         driverChecked
       );
     }
-  }, [driverChecked]);
+  }, [driverChecked, user?.vehicles]);
 
   useEffect(() => {
     setDriverChecked(authUser?.uid === driverId);
@@ -281,7 +281,7 @@ function DriverBar({
           />
         ) : null}
       </RideCardBar>
-      {authUser?.uid === driverId && isActive ? (
+      {driverChecked && isActive ? (
         <RideCardBar>
           <Text>Vehicle: </Text>
           <ChooseCar


### PR DESCRIPTION
Resolves #310 
There are several tricky edge cases that this bug has to consider which should all work as expected now.

1. The ride in the database should not be updated until a car is selected. There should be NO way to become the driver in the database without an associated car (they will appear to be the driver but it won't persist if they don't add a car).
2. If the user joins and already has a car then the ride should automatically select their first car and update the database with them as the driver.
3. If a driver joins without a car then they will be presented with an option to add a car. If they reload the page instead of adding a car then the "Driver" toggle will be reset so they aren't the driver.
4. If a driver joins without a car and then adds a car they can immediately reload the page and they will be the driver.