### PR TITLE
Fixing group list overlap mobile

### DIFF
--- a/frontend/src/components/Groups/GroupSelector.tsx
+++ b/frontend/src/components/Groups/GroupSelector.tsx
@@ -24,7 +24,12 @@ import { storage } from "../../firebase/storage";
 import { NavConstants } from "../../NavigationConstants";
 import { groupLogos, styleColors } from "../../theme/colours";
 import * as icons from "react-icons/gi";
-import { FaChevronLeft, FaChevronRight, FaPlus } from "react-icons/fa";
+import {
+  FaAlignJustify,
+  FaChevronLeft,
+  FaChevronRight,
+  FaPlus,
+} from "react-icons/fa";
 import GroupSearch from "./GroupSearch";
 
 const GroupList = (props: { updateGroups?: (groups: Group[]) => void }) => {
@@ -70,12 +75,12 @@ const GroupList = (props: { updateGroups?: (groups: Group[]) => void }) => {
       {!isOpen ? (
         <IconButton
           position="fixed"
-          bottom={0}
           aria-label="toggle-group-list"
-          m={3}
-          mt={5}
+          ml={-2}
+          mt={"50vh"}
           icon={<FaChevronRight />}
           onClick={() => (isOpen ? onClose() : onOpen())}
+          variant="ghost"
         />
       ) : null}
       <Drawer

--- a/frontend/src/components/Groups/GroupSelector.tsx
+++ b/frontend/src/components/Groups/GroupSelector.tsx
@@ -24,12 +24,7 @@ import { storage } from "../../firebase/storage";
 import { NavConstants } from "../../NavigationConstants";
 import { groupLogos, styleColors } from "../../theme/colours";
 import * as icons from "react-icons/gi";
-import {
-  FaAlignJustify,
-  FaChevronLeft,
-  FaChevronRight,
-  FaPlus,
-} from "react-icons/fa";
+import { FaChevronLeft, FaChevronRight, FaPlus } from "react-icons/fa";
 import GroupSearch from "./GroupSearch";
 
 const GroupList = (props: { updateGroups?: (groups: Group[]) => void }) => {


### PR DESCRIPTION
I just checked how a bunch of mobile apps handle this problem. Almost universally they have a small header at the top that floats at the top of the page when you scroll. All the important buttons such as the groups list, chat, etc are on the header and don't overlap with anything since they are on the header.
Resolves #330 