### PR TITLE
Group selector overlap

### DIFF
--- a/frontend/src/components/FileDropzone.tsx
+++ b/frontend/src/components/FileDropzone.tsx
@@ -21,6 +21,7 @@ const FileDropzone = (props: {
       status: "success",
       description:
         "Your file has been selected and will be uploaded when you confirm group creation.",
+      isClosable: true,
     });
     props.parentCallback(file);
   }, []);

--- a/frontend/src/components/Groups/GroupSelector.tsx
+++ b/frontend/src/components/Groups/GroupSelector.tsx
@@ -100,7 +100,7 @@ const GroupList = (props: { updateGroups?: (groups: Group[]) => void }) => {
       </Drawer>
     </>
   ) : (
-    <Box h="100vh" bg={styleColors.mainBlue} position="fixed">
+    <Box h="100vh" bg={styleColors.mainBlue} position="sticky" top={0}>
       <ListContents
         userGroups={userGroups ?? []}
         isMobile={isMobile}

--- a/frontend/src/components/Groups/GroupSelector.tsx
+++ b/frontend/src/components/Groups/GroupSelector.tsx
@@ -120,7 +120,7 @@ const ListContents = ({
   isMobile: boolean | undefined;
 }) => {
   return (
-    <VStack mt={5} mx={5} alignItems={"stretch"}>
+    <VStack mt={5} mx={2} spacing={3}>
       {userGroups?.map((group, i) => (
         <GroupListElement
           key={group.id}

--- a/frontend/src/pages/GroupPage.tsx
+++ b/frontend/src/pages/GroupPage.tsx
@@ -66,18 +66,21 @@ export default function GroupPage() {
   const [group, loading, error] = useGroup(groupId);
 
   return (
-    <HStack alignItems="flex-start" spacing={0}>
-      <GroupSelector />
-      {loading ? (
-        <LoadingPage />
-      ) : error ? (
-        <Text>{JSON.stringify(error)}</Text>
-      ) : group ? (
-        <SingleGroup group={group} />
-      ) : (
-        <Text>No such group exists</Text>
-      )}
-    </HStack>
+    <>
+      <Header tutorialSteps={tutorialSteps} />
+      <HStack alignItems="flex-start" spacing={0}>
+        <GroupSelector />
+        {loading ? (
+          <LoadingPage />
+        ) : error ? (
+          <Text>{JSON.stringify(error)}</Text>
+        ) : group ? (
+          <SingleGroup group={group} />
+        ) : (
+          <Text>No such group exists</Text>
+        )}
+      </HStack>
+    </>
   );
 }
 
@@ -91,7 +94,6 @@ const SingleGroup = ({ group }: { group: Val<Group> }) => {
 
   return (
     <Box flexGrow={1}>
-      <Header tutorialSteps={tutorialSteps} />
       {bannerLoading || error ? (
         <Box
           bg={styleColors.mainBlue}


### PR DESCRIPTION
Fixing the scrolling behaviour and overlap of the `Group Selector` component on the Welcome and Group pages. The group selector now starts below the header and scrolls up until the header goes off screen. Then the group selector stops scrolling.
Test it on the welcome page, on a group page with a banner, and a group page without a banner.
Resolves #355 