### PR TITLE
Fixing group search styling

### DIFF
--- a/frontend/src/components/Groups/GroupCapacity.tsx
+++ b/frontend/src/components/Groups/GroupCapacity.tsx
@@ -1,15 +1,44 @@
 import * as React from "react";
 import { Group } from "../../firebase/database";
-import { Text } from "@chakra-ui/react";
+import { Tag, Text } from "@chakra-ui/react";
 import { groupMaxSize } from "../Promotional/PriceSelector";
+import { styleColors } from "../../theme/colours";
 
 const GroupCapacity = (props: { group: Group }) => {
   return (
     <Text>
-      {Object.keys(props.group.members).length} /
-      {groupMaxSize(props.group.plan)}
+      {Object.keys(props.group.members).length / groupMaxSize(props.group.plan)}
     </Text>
   );
+};
+
+interface FillBreakpoint {
+  fillPoint: number;
+  colour: string;
+}
+
+const breakpoints: Array<FillBreakpoint> = [
+  {
+    fillPoint: 0.4,
+    colour: styleColors.mint,
+  },
+  {
+    fillPoint: 0.7,
+    colour: "#ED8936",
+  },
+  {
+    fillPoint: 0.99,
+    colour: "#E53E3E",
+  },
+];
+
+export const GroupCapacityBadge = (props: { group: Group }) => {
+  const fillLevel =
+    Object.keys(props.group.members).length / groupMaxSize(props.group.plan);
+  const breakPoint = breakpoints.find(
+    (b: FillBreakpoint) => b.fillPoint >= fillLevel
+  );
+  return <Tag bg={breakPoint?.colour} borderRadius={15} />;
 };
 
 export default GroupCapacity;

--- a/frontend/src/components/Groups/GroupSearch.tsx
+++ b/frontend/src/components/Groups/GroupSearch.tsx
@@ -19,12 +19,11 @@ import {
   Center,
   Tooltip,
 } from "@chakra-ui/react";
-import GroupJoinButton from "./GroupJoinButton";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { auth } from "../../firebase/firebase";
 import { useState } from "react";
 import { Group } from "../../firebase/database";
-import GroupCapacity from "./GroupCapacity";
+import { GroupCapacityBadge } from "./GroupCapacity";
 import { useNavigate } from "react-router-dom";
 import { ImSearch } from "react-icons/im";
 
@@ -64,7 +63,7 @@ const GroupSearch = (props: { groups: Group[] }) => {
 
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
-        <ModalContent>
+        <ModalContent maxW={{ base: "90%", md: "50%", lg: "30%" }}>
           <ModalHeader textAlign={"center"}>
             {publicGroups.length > 0
               ? "Found Public Groups"
@@ -79,10 +78,10 @@ const GroupSearch = (props: { groups: Group[] }) => {
               placeholder="Find Public Groups"
               borderRadius={5}
             />
-            <VStack>
+            <VStack my={5}>
               {publicGroups.length === 0 ? (
                 <Box>
-                  <Text>
+                  <Text mt={5}>
                     Please refine your search request or create your own group.
                   </Text>
                   <Center>
@@ -95,17 +94,19 @@ const GroupSearch = (props: { groups: Group[] }) => {
                 publicGroups.map((publicGroup: Group, i: number) => {
                   return (
                     <HStack key={i} w="full">
-                      <Heading size="sm">{publicGroup.name}</Heading>
+                      <Heading size="sm" maxW={"40%"}>
+                        {publicGroup.name}
+                      </Heading>
                       <Spacer />
-                      <GroupCapacity group={publicGroup} />
+                      <GroupCapacityBadge group={publicGroup} />
                       <Button
                         onClick={() =>
                           navigate(`/group/${publicGroup.id}/join`)
                         }
+                        size={"sm"}
                       >
                         Preview
                       </Button>
-                      <GroupJoinButton group={publicGroup} userId={user?.uid} />
                     </HStack>
                   );
                 })


### PR DESCRIPTION
Cleaning up the styling on the group search modal.
Added dynamic sizing for different sized screens.
Fixed the alignment and padding issues
Replaced the group capacity with a colour indicator of how full the group is. It shows green if the group is mostly empty, yellow if the group is half full and red if the group is full.
Resolves #357 