### PR TITLE
Chat send icon

### DIFF
--- a/frontend/src/components/Groups/Chat.tsx
+++ b/frontend/src/components/Groups/Chat.tsx
@@ -5,7 +5,6 @@ import {
   IconButton,
   Input,
   InputGroup,
-  InputRightAddon,
   InputRightElement,
   Spinner,
   Text,

--- a/frontend/src/components/Groups/Chat.tsx
+++ b/frontend/src/components/Groups/Chat.tsx
@@ -1,5 +1,17 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Box, Flex, Input, Spinner, Text, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  IconButton,
+  Input,
+  InputGroup,
+  InputRightAddon,
+  InputRightElement,
+  Spinner,
+  Text,
+  useColorModeValue,
+  VStack,
+} from "@chakra-ui/react";
 import { useAuthState } from "react-firebase-hooks/auth";
 import {
   getUser,
@@ -13,7 +25,8 @@ import {
   addChatToRideChat,
 } from "../../firebase/database";
 import { auth } from "../../firebase/firebase";
-import { lightTheme } from "../../theme/colours";
+import { lightTheme, styleColors } from "../../theme/colours";
+import { IoMdSend } from "react-icons/io";
 
 export const GroupChat = ({ groupId }: { groupId: string }) => (
   <Chat dbLocation={{ chatType: "group", id: groupId }} />
@@ -27,18 +40,39 @@ const ChatTextBox = ({
   addChat,
 }: {
   addChat: (message: string) => Promise<void>;
-}) => (
-  <Box w="95%">
-    <Input
-      onKeyDown={(e) => {
-        if (e.key == "Enter" && e.currentTarget.value !== "") {
-          addChat(e.currentTarget.value);
-          e.currentTarget.value = "";
-        }
-      }}
-    />
-  </Box>
-);
+}) => {
+  const [message, setMessage] = useState("");
+  return (
+    <Box w="95%">
+      <InputGroup>
+        <Input
+          onKeyDown={(e) => {
+            if (e.key == "Enter" && message !== "") {
+              addChat(message);
+              setMessage("");
+            }
+          }}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Send a message"
+          value={message}
+        />
+        <InputRightElement>
+          <IconButton
+            aria-label="send-message"
+            icon={<IoMdSend />}
+            variant="ghost"
+            onClick={() => {
+              addChat(message);
+              setMessage("");
+            }}
+            isDisabled={message.length <= 0}
+            color={useColorModeValue(styleColors.medBlue, styleColors.mainBlue)}
+          />
+        </InputRightElement>
+      </InputGroup>
+    </Box>
+  );
+};
 
 const Chat = ({
   dbLocation,


### PR DESCRIPTION
Adding an icon to the chat input as an alternative to the "return" key.
Also adding a placeholder for consistency with other inputs.
![image](https://user-images.githubusercontent.com/32989729/160974119-d83d248e-ee5c-4ec3-af4d-9515bfac4d65.png)
![image](https://user-images.githubusercontent.com/32989729/160974144-34b9960b-8c12-4e36-a02e-a6d644e846a5.png)
![image](https://user-images.githubusercontent.com/32989729/160974158-b653bac5-98d1-4204-804c-b991361a9291.png)

Resolves #394 