### PR TITLE
Add Indicators to GroupSelectorElements

### DIFF
--- a/frontend/src/components/Groups/GroupSelector.tsx
+++ b/frontend/src/components/Groups/GroupSelector.tsx
@@ -21,6 +21,7 @@ import { styleColors } from "../../theme/colours";
 import { FaChevronLeft, FaChevronRight, FaPlus } from "react-icons/fa";
 import GroupSearch from "./GroupSearch";
 import GroupAvatar from "./GroupAvatar";
+import { useParams } from "react-router-dom";
 
 const GroupList = (props: { updateGroups?: (groups: Group[]) => void }) => {
   const [user] = useAuthState(auth);
@@ -156,6 +157,10 @@ const GroupListElement = (props: {
   index: number;
   isMobile: boolean | undefined;
 }) => {
+  const groupId = useParams()["groupId"];
+  const isCurrentGroup = () => {
+    return groupId === props.group.id;
+  };
   const navigate = useNavigate();
   return props.isMobile ? (
     <>
@@ -176,7 +181,7 @@ const GroupListElement = (props: {
       <Button
         mt={4}
         onClick={() => navigate(NavConstants.groupWithId(props.group.id))}
-        variant="ghost"
+        variant={isCurrentGroup() ? "tandem-group-current" : "tandem-group"}
       >
         <GroupAvatar group={props.group} index={props.index} />
       </Button>

--- a/frontend/src/theme/components/button.tsx
+++ b/frontend/src/theme/components/button.tsx
@@ -69,6 +69,18 @@ const Button: ComponentStyleConfig = {
           bg: styleColors.paleBlue,
         },
       },
+      _focus: {
+        boxShadow: "none",
+        _before: {
+          content: `""`,
+          position: "absolute",
+          left: "2px",
+          width: "6px",
+          height: "100%",
+          borderRadius: "3px",
+          bg: styleColors.paleBlue,
+        },
+      },
     },
     "tandem-group-current": {
       bg: "transparent",
@@ -80,6 +92,9 @@ const Button: ComponentStyleConfig = {
         height: "100%",
         borderRadius: "3px",
         bg: styleColors.darkBlue,
+      },
+      _focus: {
+        boxShadow: "none",
       },
     },
     signInWith: {

--- a/frontend/src/theme/components/button.tsx
+++ b/frontend/src/theme/components/button.tsx
@@ -56,6 +56,32 @@ const Button: ComponentStyleConfig = {
       bgColor: styleColors.medGreen,
       _hover: { bg: styleColors.green },
     },
+    "tandem-group": {
+      bg: "transparent",
+      _hover: {
+        _before: {
+          content: `""`,
+          position: "absolute",
+          left: "2px",
+          width: "6px",
+          height: "100%",
+          borderRadius: "3px",
+          bg: styleColors.paleBlue,
+        },
+      },
+    },
+    "tandem-group-current": {
+      bg: "transparent",
+      _before: {
+        content: `""`,
+        position: "absolute",
+        left: "2px",
+        width: "6px",
+        height: "100%",
+        borderRadius: "3px",
+        bg: styleColors.darkBlue,
+      },
+    },
     signInWith: {
       bg: styleColors.paleBlue,
       textColor: "white",


### PR DESCRIPTION
Closes #392 

Used paleBlue for hover and darkBlue for current, can be changed.

![Screen Shot 2022-03-30 at 9 02 21 PM](https://user-images.githubusercontent.com/43759986/160974281-1840ee77-9148-4ce8-9224-c4a2ec8384d2.png)
