### PR TITLE
Allowing default time

### DIFF
--- a/frontend/src/pages/CreateRide.tsx
+++ b/frontend/src/pages/CreateRide.tsx
@@ -118,7 +118,9 @@ const CreateRide = () => {
     undefined
   );
   const [startDate, setStartDate] = useState("");
-  const [startTime, setStartTime] = useState("");
+
+  const currentTime = getCurrentTime();
+  const [startTime, setStartTime] = useState(currentTime);
   const { nextStep, prevStep, setStep, activeStep } = useSteps({
     initialStep: 0,
   });
@@ -133,8 +135,6 @@ const CreateRide = () => {
       })
       .join(":");
   }
-
-  const currentTime = getCurrentTime();
 
   const navigate = useNavigate();
 


### PR DESCRIPTION
Allow the user to proceed past the "start time" step in create ride using the default time.
Firefox doesn't have the small clock or calendar icons to the right of the input so I don't know how to fix the colour of those.
Resolves #399 