### PR TITLE
Fixing null user name in sharelink and settings page

### DIFF
--- a/frontend/src/components/Groups/ShareLink.tsx
+++ b/frontend/src/components/Groups/ShareLink.tsx
@@ -17,11 +17,15 @@ import { useState } from "react";
 import { CheckIcon, CopyIcon } from "@chakra-ui/icons";
 import { User } from "firebase/auth";
 import { FaShareSquare } from "react-icons/fa";
+import { useUser } from "../../firebase/database";
 
 const ShareLink = (props: { user: User | null | undefined }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [value, setValue] = useState("");
-  const context = `${props.user?.displayName} invited you to join their Tandem group! Follow the link to join the group: \n`;
+  const [userData] = useUser(props.user?.uid);
+  const context = `${
+    userData?.name ?? "A friend has"
+  } invited you to join their Tandem group! Follow the link to join the group: \n`;
   const { hasCopied, onCopy } = useClipboard(context + value);
   const url = window.location.href;
   return (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -34,6 +34,7 @@ import { useNavigate } from "react-router-dom";
 import { Step } from "react-joyride";
 import Tutorial from "./Tutorial";
 import LogoName from "./Promotional/LogoName";
+import { useUser } from "../firebase/database";
 
 const Header = ({
   isNested,
@@ -89,6 +90,7 @@ const Header = ({
 const Settings = (props: { user: User }) => {
   const [userModalOpen, setUserModalOpen] = useState(false);
   const user = props.user;
+  const [userData] = useUser(user.uid);
   return (
     <MenuItem onClick={() => setUserModalOpen(true)}>
       Settings
@@ -100,7 +102,7 @@ const Settings = (props: { user: User }) => {
         <ModalContent h={"container.sm"} padding={"4"} w={"95%"}>
           <ModalCloseButton />
           <ModalHeader>
-            {user?.displayName}
+            {userData?.name}
             <ColorModeSwitcher float={"right"} />
           </ModalHeader>
           <ModalBody>

--- a/frontend/src/pages/CreateGroup.tsx
+++ b/frontend/src/pages/CreateGroup.tsx
@@ -163,7 +163,7 @@ const CreateGroup = () => {
             <Input
               id="group-name"
               value={name}
-              placeholder={"name"}
+              placeholder={"Group Name"}
               onInput={(e) =>
                 setName({
                   field: e.currentTarget.value,


### PR DESCRIPTION
Fixing issues where the user's name would display as "null". Including group share link and settings page.
Resolves #381 