### PR TITLE
Fixing modal content width

### DIFF
--- a/frontend/src/components/Groups/GroupInfo.tsx
+++ b/frontend/src/components/Groups/GroupInfo.tsx
@@ -101,7 +101,7 @@ const GroupInfo = ({ group, userId }: { group: Group; userId: string }) => {
 
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
-        <ModalContent maxW={{ base: "90%", md: "70%", lg: "40%" }} p={15}>
+        <ModalContent maxW={{ base: "90%", md: "70%", lg: "60%" }} p={15}>
           <ModalHeader>{isOwner ? "Group Settings" : "Group Info"}</ModalHeader>
           <ModalCloseButton />
           <ModalBody>


### PR DESCRIPTION
Before
<img width="525" alt="image" src="https://user-images.githubusercontent.com/32989729/161326759-64abc4d1-c547-4bcc-8857-9c1ea13bd794.png">
After
<img width="944" alt="image" src="https://user-images.githubusercontent.com/32989729/161326778-d08ed8a7-8d27-4d14-b98c-5cc9bfb29c39.png">
